### PR TITLE
Fix filter_aniframe: work without an individual column (#16)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # aniprocess 0.2.0 (development version)
 
+* `filter_aniframe()` now reads identity columns from the `variables_what`
+  metadata field and spatial columns from `variables_where`, instead of
+  hard-coding `individual` / `keypoint` / `x` / `y` / `z`. Identity columns
+  named in metadata but absent from the data are silently skipped, so the
+  function works on single-track data (e.g. Octron) without an `individual`
+  column (#16).
+
 # aniprocess 0.1.2
 
 * Added a `NEWS.md` file to track changes to the package.

--- a/R/filter_aniframe.R
+++ b/R/filter_aniframe.R
@@ -5,15 +5,12 @@
 #'
 #' Applies smoothing filters to movement tracking data to reduce noise.
 #'
-#' @param data A data frame containing movement tracking data with the following
-#'   required columns:
-#'   - `individual`: Identifier for each tracked subject
-#'   - `keypoint`: Identifier for each tracked point
-#'   - `x`: x-coordinates
-#'   - `y`: y-coordinates
-#'   - `time`: Time values
-#'   Optional columns:
-#'   - `z`: z-coordinates
+#' @param data An aniframe. Spatial columns to filter are taken from the
+#'   metadata field `variables_where` (e.g. `c("x", "y")` or `c("x", "y", "z")`).
+#'   Filtering is applied within the aniframe's existing grouping, which is
+#'   driven by `variables_what` (e.g. `c("individual", "keypoint")`, `"track"`,
+#'   or `character(0)` for a single trajectory). Single-track data without an
+#'   `individual` column is supported.
 #' @param method Character string specifying the smoothing method. Options:
 #'   - `"kalman"`: Kalman filter (see [filter_kalman()])
 #'   - `"sgolay"`: Savitzky-Golay filter (see [filter_sgolay()])
@@ -28,9 +25,10 @@
 #' @param ... Additional arguments passed to the specific filter function
 #'
 #' @details
-#' This function is a wrapper that applies various filtering methods to x and y
-#' (and z if present) coordinates. Each filtering method has its own specific
-#' parameters - see the documentation of individual filter functions for details:
+#' This function is a wrapper that applies the chosen filter to every spatial
+#' coordinate listed in `variables_where`, respecting the aniframe's existing
+#' grouping. Each filtering method has its own specific parameters - see the
+#' documentation of the individual filter functions for details:
 #'
 #' * [filter_kalman()]: Kalman filter parameters
 #' * [filter_sgolay()]: Savitzky-Golay filter parameters
@@ -41,8 +39,8 @@
 #' * [filter_rollmean()]: Rolling mean parameters (window_width, min_obs)
 #' * [filter_rollmedian()]: Rolling median parameters (window_width, min_obs)
 #'
-#' @return A data frame with the same structure as the input, but with smoothed
-#'   coordinates.
+#' @return An aniframe with the same structure as the input, but with smoothed
+#'   spatial coordinates.
 #'
 #' @examples
 #' \dontrun{
@@ -78,12 +76,20 @@ filter_aniframe <- function(
 ) {
   method <- match.arg(method)
 
-  # Input validation
-  if (!aniframe::is_aniframe(data)) {
-    cli::cli_abort("Data is not an aniframe.")
+  aniframe::ensure_is_aniframe(data)
+
+  variables_where <- aniframe::get_metadata(data, "variables_where")
+
+  missing_where <- setdiff(variables_where, names(data))
+  if (length(missing_where) > 0) {
+    cli::cli_abort(
+      c(
+        "Missing spatial column{?s}: {.val {missing_where}}.",
+        "i" = "Spatial variables from metadata: {.val {variables_where}}."
+      )
+    )
   }
 
-  # Select appropriate filter function
   filter_fn <- switch(
     method,
     rollmean = filter_rollmean,
@@ -97,55 +103,24 @@ filter_aniframe <- function(
     cli::cli_abort("Invalid method: {method}")
   )
 
+  # Materialise dots so per-column lambdas don't depend on tidyeval `...`
+  extra_args <- rlang::list2(...)
+  apply_filter <- function(col) do.call(filter_fn, c(list(col), extra_args))
+
   if (isFALSE(use_derivatives)) {
-    # Apply filter to coordinates
-    data <- data |>
-      dplyr::group_by(.data$individual, .data$keypoint) |>
-      dplyr::mutate(
-        x = filter_fn(.data$x, ...),
-        y = filter_fn(.data$y, ...)
-      )
-
-    # If z coordinate exists, filter it too
-    if ("z" %in% names(data)) {
-      data <- data |>
-        dplyr::mutate(
-          z = filter_fn(.data$z, ...)
-        )
-    }
+    dplyr::mutate(
+      data,
+      dplyr::across(dplyr::all_of(variables_where), apply_filter)
+    )
   } else {
-    # Apply filter to derivatives
-    data <- data |>
-      dplyr::group_by(.data$individual, .data$keypoint) |>
-      dplyr::mutate(
-        dx = .data$x - dplyr::lag(.data$x),
-        dy = .data$y - dplyr::lag(.data$y)
-      ) |>
-      dplyr::mutate(
-        dx = filter_fn(.data$dx, ...),
-        dy = filter_fn(.data$dy, ...)
-      ) |>
-      dplyr::mutate(
-        x = cumsum(dplyr::coalesce(.data$dx, 0)) + .data$dx * 0,
-        y = cumsum(dplyr::coalesce(.data$dy, 0)) + .data$dy * 0
-      ) |>
-      dplyr::select(-"dx", -"dy")
-
-    # If z coordinate exists, filter it too
-    if ("z" %in% names(data)) {
-      data <- data |>
-        dplyr::mutate(
-          dz = .data$z - dplyr::lag(.data$z)
-        ) |>
-        dplyr::mutate(
-          dz = filter_fn(.data$dz, ...)
-        ) |>
-        dplyr::mutate(
-          z = cumsum(dplyr::coalesce(.data$dz, 0)) + .data$dz * 0
-        ) |>
-        dplyr::select(-"dz")
+    integrate_filtered <- function(col) {
+      d <- col - dplyr::lag(col)
+      d <- apply_filter(d)
+      cumsum(dplyr::coalesce(d, 0)) + d * 0
     }
+    dplyr::mutate(
+      data,
+      dplyr::across(dplyr::all_of(variables_where), integrate_filtered)
+    )
   }
-
-  data
 }

--- a/man/filter_aniframe.Rd
+++ b/man/filter_aniframe.Rd
@@ -13,17 +13,12 @@ filter_aniframe(
 )
 }
 \arguments{
-\item{data}{A data frame containing movement tracking data with the following
-required columns:
-\itemize{
-\item \code{individual}: Identifier for each tracked subject
-\item \code{keypoint}: Identifier for each tracked point
-\item \code{x}: x-coordinates
-\item \code{y}: y-coordinates
-\item \code{time}: Time values
-Optional columns:
-\item \code{z}: z-coordinates
-}}
+\item{data}{An aniframe. Spatial columns to filter are taken from the
+metadata field \code{variables_where} (e.g. \code{c("x", "y")} or \code{c("x", "y", "z")}).
+Filtering is applied within the aniframe's existing grouping, which is
+driven by \code{variables_what} (e.g. \code{c("individual", "keypoint")}, \code{"track"},
+or \code{character(0)} for a single trajectory). Single-track data without an
+\code{individual} column is supported.}
 
 \item{method}{Character string specifying the smoothing method. Options:
 \itemize{
@@ -43,8 +38,8 @@ Optional columns:
 \item{...}{Additional arguments passed to the specific filter function}
 }
 \value{
-A data frame with the same structure as the input, but with smoothed
-coordinates.
+An aniframe with the same structure as the input, but with smoothed
+spatial coordinates.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
@@ -52,9 +47,10 @@ coordinates.
 Applies smoothing filters to movement tracking data to reduce noise.
 }
 \details{
-This function is a wrapper that applies various filtering methods to x and y
-(and z if present) coordinates. Each filtering method has its own specific
-parameters - see the documentation of individual filter functions for details:
+This function is a wrapper that applies the chosen filter to every spatial
+coordinate listed in \code{variables_where}, respecting the aniframe's existing
+grouping. Each filtering method has its own specific parameters - see the
+documentation of the individual filter functions for details:
 \itemize{
 \item \code{\link[=filter_kalman]{filter_kalman()}}: Kalman filter parameters
 \item \code{\link[=filter_sgolay]{filter_sgolay()}}: Savitzky-Golay filter parameters

--- a/tests/testthat/test-filter_aniframe.R
+++ b/tests/testthat/test-filter_aniframe.R
@@ -1,8 +1,100 @@
-# Test arguments
+# Tests for filter_aniframe
+# - Default example_aniframe (groups by individual + keypoint)
+# - Custom variables_what (e.g. single "track" column)
+# - No grouping when no variables_what columns exist in the data (#16)
+# - Validates aniframe input
+# - Errors when a variables_where column is missing
+# - Filters z when present in variables_where
+# - use_derivatives branch
+# - Returns an aniframe
 
-df <- aniframe::example_aniframe()
+test_that("filter_aniframe works with default example_aniframe", {
+  d <- aniframe::example_aniframe()
+  expect_no_error(filter_aniframe(d))
+  expect_s3_class(filter_aniframe(d), "aniframe")
+})
 
-# Check that smoothing functions work
-test_that("Test output header names", {
-  expect_no_error(filter_aniframe(df))
+test_that("filter_aniframe works with a single custom identity column", {
+  n <- 20
+  d <- aniframe::aniframe(
+    track = rep(c("a", "b"), each = n / 2),
+    time = rep(1:(n / 2), 2),
+    x = rnorm(n),
+    y = rnorm(n),
+    variables_what = "track"
+  )
+  expect_no_error(filter_aniframe(d, "rollmean", window_width = 3, min_obs = 1))
+})
+
+test_that("filter_aniframe works without an `individual` column (#16)", {
+  # Single trajectory, no identity columns at all.
+  # Reproduces the failure path reported in #16.
+  d <- aniframe::aniframe(
+    time = 1:20,
+    x = rnorm(20),
+    y = rnorm(20),
+    variables_what = character(0)
+  )
+  expect_no_error(filter_aniframe(d, "rollmean", window_width = 3, min_obs = 1))
+})
+
+test_that("filter_aniframe is robust when variables_what names a missing column", {
+  # aniframe sometimes carries a default variables_what (e.g. "keypoint")
+  # even when the column is absent. The function should silently skip those.
+  d <- aniframe::aniframe(
+    time = 1:20,
+    x = rnorm(20),
+    y = rnorm(20)
+  )
+  expect_no_error(filter_aniframe(d, "rollmean", window_width = 3, min_obs = 1))
+})
+
+test_that("filter_aniframe errors when a variables_where column is missing", {
+  d <- aniframe::aniframe(
+    time = 1:5,
+    x = 1:5,
+    y = 1:5
+  )
+  d <- aniframe::set_metadata(d, variables_where = c("x", "y", "z"))
+  expect_error(filter_aniframe(d), "Missing spatial column")
+})
+
+test_that("filter_aniframe filters z when present", {
+  n <- 20
+  d <- aniframe::aniframe(
+    time = 1:n,
+    x = rnorm(n),
+    y = rnorm(n),
+    z = rnorm(n),
+    variables_where = c("x", "y", "z")
+  )
+  result <- filter_aniframe(d, "rollmean", window_width = 3, min_obs = 1)
+  # All three spatial columns should have been smoothed (different from input)
+  expect_false(identical(result$x, d$x))
+  expect_false(identical(result$y, d$y))
+  expect_false(identical(result$z, d$z))
+})
+
+test_that("filter_aniframe handles use_derivatives", {
+  n <- 20
+  d <- aniframe::aniframe(
+    time = 1:n,
+    x = cumsum(rnorm(n)),
+    y = cumsum(rnorm(n)),
+    variables_what = character(0)
+  )
+  expect_no_error(
+    filter_aniframe(
+      d,
+      "rollmean",
+      window_width = 3,
+      min_obs = 1,
+      use_derivatives = TRUE
+    )
+  )
+})
+
+test_that("filter_aniframe rejects non-aniframe input", {
+  d <- data.frame(time = 1:5, x = 1:5, y = 1:5)
+  expect_error(filter_aniframe(d), class = "rlang_error")
 })

--- a/tests/testthat/test-filter_aniframe.R
+++ b/tests/testthat/test-filter_aniframe.R
@@ -1,11 +1,12 @@
 # Tests for filter_aniframe
 # - Default example_aniframe (groups by individual + keypoint)
 # - Custom variables_what (e.g. single "track" column)
-# - No grouping when no variables_what columns exist in the data (#16)
-# - Validates aniframe input
+# - Single-track data with no identity columns at all (#16 repro)
+# - Robustness when variables_what metadata names a column not in the data
 # - Errors when a variables_where column is missing
-# - Filters z when present in variables_where
-# - use_derivatives branch
+# - Filters z when listed in variables_where
+# - use_derivatives branch (derive -> filter -> integrate)
+# - Rejects non-aniframe input
 # - Returns an aniframe
 
 test_that("filter_aniframe works with default example_aniframe", {


### PR DESCRIPTION
Closes #16.

## The bug
`filter_aniframe()` hard-coded `dplyr::group_by(.data$individual, .data$keypoint)` and hard-coded references to `x`/`y`/`z`. On data without an `individual` column (e.g. Octron's single-track output), it errored out:

```
Error in `dplyr::group_by()`:
! Must group by variables found in `.data`.
✖ Column `individual` is not found.
```

## The fix
Two changes, both metadata-driven:

1. **Spatial columns come from `variables_where`.** No more hard-coded `x`/`y`/`z`. Whatever the metadata names — `c("x", "y")`, `c("x", "y", "z")`, or anything else — gets filtered.
2. **Drop the manual grouping.** Aniframes are pre-grouped at construction (`as_aniframe()` does `group_by(variables_what + (variables_when - time))`), and `mutate.aniframe` respects that grouping. The function now just does `dplyr::mutate(across(all_of(variables_where), …))` and inherits the right grouping for free. This also makes the result correct for multi-session data, where the old hard-coded `group_by(individual, keypoint)` would have smoothed across session/trial boundaries.

## Other notes
- The derivative branch is now expressed as a single `across()` lambda that derives → filters → integrates per spatial column, instead of three near-identical x/y/z blocks.
- `...` is materialised once via `rlang::list2(...)` and passed through `do.call` so the per-column lambda doesn't depend on tidyeval `...` propagation.
- Tests rewritten to cover: default `example_aniframe()`, custom single identity column (`track`), single-track data with no identity columns (the #16 repro), `variables_what` naming a missing column (silently skipped, matching aniframe's own tolerance), missing `variables_where` column (errors), 3D data, `use_derivatives`, non-aniframe input.

## Test plan
- [x] `devtools::test()` — all tests pass, no warnings.
- [x] Manual repro of the #16 traceback verified fixed.
- [ ] `R CMD check` (defer to release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
