### PR TITLE
Fix r-universe URLs left over from repo move (#17)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@
 * Point `replace_na_stine()` and `filter_bandwidth.R`'s inline package
   installer at `animovement.r-universe.dev` (#17). Both were still
   referencing the old `roaldarbol` r-universe after the repo move.
+  Both call sites now route through `check_*()` helpers in
+  `R/check_installed.R` (added `check_stinepack()`, replaced an inline
+  `check_installed("signal", …)` in `filter_highpass()` with
+  `check_signal()`) so the canonical URL only lives in one place.
 
 # aniprocess 0.1.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # aniprocess 0.2.0 (development version)
 
+* Point `replace_na_stine()` and `filter_bandwidth.R`'s inline package
+  installer at `animovement.r-universe.dev` (#17). Both were still
+  referencing the old `roaldarbol` r-universe after the repo move.
+
 # aniprocess 0.1.2
 
 * Added a `NEWS.md` file to track changes to the package.

--- a/R/check_installed.R
+++ b/R/check_installed.R
@@ -33,6 +33,23 @@ check_signal <- function() {
 }
 
 #' @keywords internal
+check_stinepack <- function() {
+  rlang::check_installed(
+    "stinepack",
+    reason = "to use Stineman interpolation",
+    action = function(...) {
+      utils::install.packages(
+        'stinepack',
+        repos = c(
+          'https://animovement.r-universe.dev',
+          'https://cloud.r-project.org'
+        )
+      )
+    }
+  )
+}
+
+#' @keywords internal
 check_animetric <- function() {
   rlang::check_installed(
     "animetric",

--- a/R/filter_bandwidth.R
+++ b/R/filter_bandwidth.R
@@ -263,7 +263,7 @@ filter_highpass <- function(
       utils::install.packages(
         'signal',
         repos = c(
-          'https://roaldarbol.r-universe.dev',
+          'https://animovement.r-universe.dev',
           'https://cloud.r-project.org'
         )
       )

--- a/R/filter_bandwidth.R
+++ b/R/filter_bandwidth.R
@@ -256,19 +256,7 @@ filter_highpass <- function(
   ...
 ) {
   # Check that signal is installed
-  rlang::check_installed(
-    "signal",
-    reason = "to use the high-pass filter",
-    action = function(...) {
-      utils::install.packages(
-        'signal',
-        repos = c(
-          'https://animovement.r-universe.dev',
-          'https://cloud.r-project.org'
-        )
-      )
-    }
-  )
+  check_signal()
 
   # Input validation
   if (!is.numeric(x)) {

--- a/R/replace_na_stine.R
+++ b/R/replace_na_stine.R
@@ -35,19 +35,7 @@
 #' @export
 replace_na_stine <- function(x, min_gap = 1, max_gap = Inf, ...) {
   # Check that stinepack is installed
-  rlang::check_installed(
-    "stinepack",
-    reason = "to use replace_na_stine()",
-    action = function(...) {
-      utils::install.packages(
-        'stinepack',
-        repos = c(
-          'https://animovement.r-universe.dev',
-          'https://cloud.r-project.org'
-        )
-      )
-    }
-  )
+  check_stinepack()
   # Input validation
   if (!is.numeric(x)) {
     cli::cli_abort("Input must be numeric")

--- a/R/replace_na_stine.R
+++ b/R/replace_na_stine.R
@@ -42,7 +42,7 @@ replace_na_stine <- function(x, min_gap = 1, max_gap = Inf, ...) {
       utils::install.packages(
         'stinepack',
         repos = c(
-          'https://roaldarbol.r-universe.dev',
+          'https://animovement.r-universe.dev',
           'https://cloud.r-project.org'
         )
       )

--- a/tests/testthat/test-check_installed.R
+++ b/tests/testthat/test-check_installed.R
@@ -1,4 +1,4 @@
-# Testing check_roll(), check_signal() and check_animetric()
+# Testing check_roll(), check_signal(), check_stinepack(), and check_animetric()
 # - Functions call rlang::check_installed with correct arguments
 # - Custom action installs from correct repositories
 # - Correct reason messages are provided
@@ -66,6 +66,39 @@ test_that("check_signal works and calls correct functions", {
   expect_type(captured_args$action, "closure")
 
   expect_equal(install_args$pkgs, "signal")
+  expect_equal(
+    install_args$repos,
+    c('https://animovement.r-universe.dev', 'https://cloud.r-project.org')
+  )
+})
+
+test_that("check_stinepack works and calls correct functions", {
+  captured_args <- NULL
+
+  local_mocked_bindings(
+    check_installed = function(pkg, reason, action) {
+      captured_args <<- list(pkg = pkg, reason = reason, action = action)
+      # Actually execute the action to get coverage
+      action()
+    },
+    .package = "rlang"
+  )
+
+  install_args <- NULL
+  local_mocked_bindings(
+    install.packages = function(pkgs, repos, ...) {
+      install_args <<- list(pkgs = pkgs, repos = repos)
+    },
+    .package = "utils"
+  )
+
+  check_stinepack()
+
+  expect_equal(captured_args$pkg, "stinepack")
+  expect_match(captured_args$reason, "Stineman interpolation")
+  expect_type(captured_args$action, "closure")
+
+  expect_equal(install_args$pkgs, "stinepack")
   expect_equal(
     install_args$repos,
     c('https://animovement.r-universe.dev', 'https://cloud.r-project.org')


### PR DESCRIPTION
Closes #17.

## URL fix
Two stragglers from the repo move still pointed at `https://roaldarbol.r-universe.dev`, which now 404s:

- `R/replace_na_stine.R` — install path for `stinepack`.
- `R/filter_bandwidth.R` — inline `rlang::check_installed` for `signal` inside `filter_highpass()`.

Both now point at `https://animovement.r-universe.dev`, matching what `R/check_installed.R` and `DESCRIPTION` already use.

## Dedup
Both call sites had inlined `rlang::check_installed` blocks, even though `R/check_installed.R` already exposes `check_*()` helpers for the same purpose. Consolidated:

- Added `check_stinepack()` mirroring the other helpers.
- `replace_na_stine()` now calls `check_stinepack()`.
- `filter_highpass()` now calls `check_signal()` (matching what `filter_lowpass()` already does).
- Test for `check_stinepack()` mirroring the existing pattern.

The canonical r-universe URL now lives in exactly one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
