### PR TITLE
Inherit shared pkgdown theming from animovementtemplate

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,6 +31,7 @@ Suggests:
     testthat (>= 3.0.0)
 Additional_repositories: https://animovement.r-universe.dev
 Config/testthat/edition: 3
+Config/Needs/website: animovement/animovementtemplate
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
 VignetteBuilder: knitr

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,30 +2,11 @@ url: http://animovement.dev/aniprocess/
 home:
   title: "aniprocess – An R toolbox for reading and writing movement data"
 
-authors:
-  - name: "Mikkel Roald‑Arbøl"
-    href: "https://roald-arboel.com"
-
+# Shared navbar (incl. the animovement dropdown + Zulip), theme, and author
+# details are inherited from animovementtemplate.
 template:
   bootstrap: 5
-  light-switch: true
-
-navbar:
-  structure:
-    left:
-      - intro
-      - reference
-      - news
-    right:
-      - search
-      - github
-      - zulip
-      - lightswitch
-  components:
-    zulip:
-      icon: fa-comments
-      href: https://animovement.zulipchat.com
-      aria-label: Chat on Zulip
+  package: animovementtemplate
 
 reference:
 - title: "Remove observations of poor quality"


### PR DESCRIPTION
## Summary

Brings the aniprocess pkgdown site in line with aniframe, anivis, and anicheck by inheriting the shared theming from the `animovementtemplate` package instead of maintaining a bespoke config.

- `_pkgdown.yml`: replaced the package-local `template`, `navbar`, and `authors` blocks with `template.package: animovementtemplate`. The navbar (including the animovement ecosystem dropdown and the Zulip link), the light-switch theme, and the author details are now inherited from the template package, so they live in one place across the ecosystem. The `url`, home title, and `reference` sections remain package-specific.
- `DESCRIPTION`: added `Config/Needs/website: animovement/animovementtemplate` (there was no `Config/Needs/website` line before) so the template package is installed when the site is built.

The existing pkgdown workflow already uses `needs: website` with `local::.`, so the GitHub-remote template installs without any workflow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)