### PR TITLE
Make argument names consistent across the package (#30)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: aniprocess
 Type: Package
 Title: An R package for signal processing and filtering of movement data
-Version: 0.2.0.9002
+Version: 0.2.0.9003
 Authors@R: 
     person(
       "Mikkel", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 ## Breaking changes
 
+* Argument names are now consistent across the package, so that a generic wrapper can forward them without special-casing. This is the first step towards the unified interface in #30 (#30).
+  * `window_size` is now `window_width` in `filter_sgolay()`, `find_peaks()` and `find_troughs()`, matching `filter_gaussian()`, `filter_rollmean()`, `filter_rollmedian()` and `filter_triangular()`.
+  * The first argument of `filter_kalman()` and `filter_kalman_irregular()` is now `x` rather than `measurements`. They were the only vector-level functions whose first argument was not `x`, which prevented their use with `dplyr::across()`.
+  * `filter_na_range()` takes `min_value`/`max_value` rather than `min`/`max`, which shadowed the base functions of those names and did not match the `min_gap`/`max_gap`/`min_obs` convention used elsewhere.
+
+  No deprecation cycle: nothing in the animovement org passes these names, verified across `aniread`, `animetric`, `aniframe`, `anicheck`, `anispace`, `anivis` and the `animovement` meta-package.
+
 * Filters no longer fill gaps by default. `keep_na` now defaults to `TRUE` in `filter_sgolay()`, `filter_lowpass()`, `filter_highpass()`, `filter_lowpass_fft()`, `filter_highpass_fft()` and `filter_ccma()`, so positions that were `NA` in the input are `NA` in the output. Previously the default was `FALSE`, which meant genuinely-missing stretches came back as smoothed interpolations with no indication that any interpolation had happened. Pass `keep_na = FALSE` for the old behaviour (#38).
 * `keep_na` is now available on every filter. `filter_gaussian()`, `filter_rollmean()`, `filter_rollmedian()` and `filter_triangular()` gain the argument, defaulting to `TRUE`; they previously filled gaps — fully or partially — with no way to opt out (#38).
 * `filter_kalman()` and `filter_kalman_irregular()` also gain `keep_na`, but default to `FALSE`. A Kalman filter's predict step is designed to carry the state estimate through missing observations, so inferring across gaps is intended rather than accidental. Pass `keep_na = TRUE` to leave gaps as gaps (#38).

--- a/R/filter_kalman.R
+++ b/R/filter_kalman.R
@@ -5,7 +5,7 @@
 #' parameter selection based on sampling rate. The filter handles missing values (NA)
 #' and provides noise reduction while preserving real signal changes.
 #'
-#' @param measurements Numeric vector containing the measurements to be filtered.
+#' @param x Numeric vector of measurements to be filtered.
 #' @param sampling_rate Numeric value specifying the sampling rate in Hz (frames per second).
 #' @param base_Q Optional. Process variance. If NULL, automatically calculated based on sampling_rate.
 #'          Represents expected rate of change in the true state.
@@ -14,37 +14,37 @@
 #' @param initial_state Optional. Initial state estimate. If NULL, uses first non-NA measurement.
 #' @param initial_P Optional. Initial state uncertainty. If NULL, calculated based on sampling_rate.
 #' @param keep_na Logical. If `TRUE`, positions that were `NA` in
-#'   `measurements` are `NA` in the output. Defaults to `FALSE`, unlike the
+#'   `x` are `NA` in the output. Defaults to `FALSE`, unlike the
 #'   rest of the filter family: a Kalman filter's predict step is designed
 #'   to carry the state estimate through missing observations, so inferring
 #'   across gaps is the intended behaviour rather than an accident. Set
 #'   `TRUE` when you want gaps left as gaps.
 #'
 #' @return
-#' A numeric vector of the same length as measurements containing the filtered values.
+#' A numeric vector of the same length as x containing the filtered values.
 #'
 #' @details
 #' The function implements a simple Kalman filter with a constant position model.
 #' When parameters are not explicitly provided, they are automatically configured based
 #' on the sampling rate:
 #'
-#' * `base_Q` defaults to `var(measurements) / sampling_rate` (so the
+#' * `base_Q` defaults to `var(x) / sampling_rate` (so the
 #'   per-step process noise `Q = base_Q / sampling_rate` shrinks at higher
 #'   sampling rates, where consecutive samples are closer together).
 #' * `R` defaults to `min(mean(diff(x)^2) / 2, var(x) / 4)` if there are
 #'   enough observations, else `0.1`.
-#' * `initial_P` defaults to `var(measurements)` if there are enough
+#' * `initial_P` defaults to `var(x)` if there are enough
 #'   observations, else `1`.
 #'
 #' Missing values (NA) are handled by relying on the prediction step without measurement updates.
 #'
 #' @examples
 #' # Basic usage with 60 Hz data
-#' measurements <- c(1, 1.1, NA, 0.9, 1.2, NA, 0.8, 1.1)
-#' filtered <- filter_kalman(measurements, sampling_rate = 60)
+#' x <- c(1, 1.1, NA, 0.9, 1.2, NA, 0.8, 1.1)
+#' filtered <- filter_kalman(x, sampling_rate = 60)
 #'
 #' # Custom parameters for more aggressive filtering
-#' filtered_custom <- filter_kalman(measurements,
+#' filtered_custom <- filter_kalman(x,
 #'                                 sampling_rate = 60,
 #'                                 base_Q = 0.001,
 #'                                 R = 0.2)
@@ -61,7 +61,7 @@
 #'
 #' @export
 filter_kalman <- function(
-  measurements,
+  x,
   sampling_rate,
   base_Q = NULL,
   R = NULL,
@@ -79,19 +79,19 @@ filter_kalman <- function(
   ) {
     stop("sampling_rate must be finite and positive")
   }
-  if (length(measurements) == 0) {
-    stop("measurements cannot be empty")
+  if (length(x) == 0) {
+    stop("x cannot be empty")
   }
-  if (all(is.na(measurements))) {
+  if (all(is.na(x))) {
     stop("At least one non-NA measurement is required")
   }
 
-  # Get valid measurements for parameter estimation
-  valid_measurements <- measurements[!is.na(measurements)]
+  # Get valid x for parameter estimation
+  valid_measurements <- x[!is.na(x)]
 
   # Improved parameter auto-configuration
   if (is.null(base_Q)) {
-    # If we have enough valid measurements for variance
+    # If we have enough valid x for variance
     if (length(valid_measurements) > 1) {
       signal_var <- stats::var(valid_measurements)
     } else {
@@ -101,7 +101,7 @@ filter_kalman <- function(
   }
 
   if (is.null(R)) {
-    # If we have enough measurements for local differences
+    # If we have enough x for local differences
     if (length(valid_measurements) > 1) {
       local_diff_var <- mean(diff(valid_measurements)^2) / 2
       R <- min(local_diff_var, stats::var(valid_measurements) / 4)
@@ -118,7 +118,7 @@ filter_kalman <- function(
     }
   }
 
-  n <- length(measurements)
+  n <- length(x)
   filtered <- numeric(n)
 
   # Initialize state
@@ -141,12 +141,12 @@ filter_kalman <- function(
     P_minus <- P + Q
 
     # Update step
-    if (!is.na(measurements[i])) {
+    if (!is.na(x[i])) {
       # Kalman gain
       K <- P_minus / (P_minus + R)
 
       # Update state estimate
-      x_hat <- x_hat_minus + K * (measurements[i] - x_hat_minus)
+      x_hat <- x_hat_minus + K * (x[i] - x_hat_minus)
 
       # Update error covariance
       P <- (1 - K) * P_minus
@@ -159,7 +159,7 @@ filter_kalman <- function(
     filtered[i] <- x_hat
   }
 
-  restore_na(filtered, is.na(measurements), keep_na)
+  restore_na(filtered, is.na(x), keep_na)
 }
 
 #' Kalman Filter for Irregular Time Series with Optional Resampling
@@ -169,8 +169,8 @@ filter_kalman <- function(
 #' resampling to regular intervals. Handles variable sampling rates, missing values,
 #' and automatically adjusts process variance based on time intervals.
 #'
-#' @param measurements Numeric vector containing the measurements to be filtered.
-#' @param times Numeric vector of timestamps corresponding to measurements.
+#' @param x Numeric vector of measurements to be filtered.
+#' @param times Numeric vector of timestamps corresponding to x.
 #' @param base_Q Optional. Base process variance per second. If NULL, automatically calculated.
 #' @param R Optional. Measurement variance. If NULL, defaults to 0.1.
 #' @param initial_state Optional. Initial state estimate. If NULL, uses first non-NA measurement.
@@ -178,7 +178,7 @@ filter_kalman <- function(
 #' @param resample Logical. Whether to return regularly resampled data (default: FALSE).
 #' @param resample_freq Numeric. Desired sampling frequency in Hz for resampling (required if resample=TRUE).
 #' @param keep_na Logical. If `TRUE`, positions that were `NA` in
-#'   `measurements` are `NA` in the values reported on the original
+#'   `x` are `NA` in the values reported on the original
 #'   timestamps. Defaults to `FALSE`, for the reason given in
 #'   [filter_kalman()]. When `resample = TRUE` this applies to
 #'   `original_values` only — the resampled `values` sit on a different
@@ -212,19 +212,19 @@ filter_kalman <- function(
 #'
 #' @examples
 #' # Example with irregular sampling
-#' measurements <- c(1, 1.1, NA, 0.9, 1.2, NA, 0.8, 1.1)
+#' x <- c(1, 1.1, NA, 0.9, 1.2, NA, 0.8, 1.1)
 #' times <- c(0, 0.1, 0.3, 0.35, 0.5, 0.8, 0.81, 1.0)
 #'
 #' # Basic filtering with irregular samples
-#' filtered <- filter_kalman_irregular(measurements, times)
+#' filtered <- filter_kalman_irregular(x, times)
 #'
 #' # Filtering with resampling to 50 Hz
-#' filtered_resampled <- filter_kalman_irregular(measurements, times,
+#' filtered_resampled <- filter_kalman_irregular(x, times,
 #'                                              resample = TRUE,
 #'                                              resample_freq = 50)
 #'
 #' # Plot results
-#' plot(times, measurements, type="p", col="blue")
+#' plot(times, x, type="p", col="blue")
 #' lines(filtered_resampled$time, filtered_resampled$values, col="red")
 #'
 #' @note
@@ -237,14 +237,14 @@ filter_kalman <- function(
 #' * base_Q controls the expected rate of change per second
 #' * R should reflect your measurement noise level
 #' * For slow-changing signals, reduce base_Q
-#' * For noisy measurements, increase R
+#' * For noisy x, increase R
 #'
 #' @seealso
 #' filter_kalman for regularly sampled data
 #'
 #' @export
 filter_kalman_irregular <- function(
-  measurements,
+  x,
   times,
   base_Q = NULL,
   R = NULL,
@@ -256,8 +256,8 @@ filter_kalman_irregular <- function(
 ) {
   ensure_keep_na(keep_na)
   # Previous input validation remains the same
-  if (length(measurements) != length(times)) {
-    stop("measurements and times must have the same length")
+  if (length(x) != length(times)) {
+    stop("x and times must have the same length")
   }
   if (!is.numeric(times)) {
     stop("times must be numeric")
@@ -265,10 +265,10 @@ filter_kalman_irregular <- function(
   if (any(is.na(times)) || any(is.infinite(times))) {
     stop("times must be finite and not NA")
   }
-  if (length(measurements) == 0) {
-    stop("measurements cannot be empty")
+  if (length(x) == 0) {
+    stop("x cannot be empty")
   }
-  if (all(is.na(measurements))) {
+  if (all(is.na(x))) {
     stop("At least one non-NA measurement is required")
   }
   if (resample && is.null(resample_freq)) {
@@ -281,12 +281,12 @@ filter_kalman_irregular <- function(
   }
   if (any(diff(times) == 0)) {
     warning(
-      "Duplicate time points detected. Using measurements in order provided."
+      "Duplicate time points detected. Using x in order provided."
     )
   }
 
-  # Get valid measurements for parameter estimation
-  valid_measurements <- measurements[!is.na(measurements)]
+  # Get valid x for parameter estimation
+  valid_measurements <- x[!is.na(x)]
 
   # Calculate median sampling rate
   time_diffs <- diff(times)
@@ -299,7 +299,7 @@ filter_kalman_irregular <- function(
 
   # Improved parameter auto-configuration
   if (is.null(base_Q)) {
-    # If we have enough valid measurements for variance
+    # If we have enough valid x for variance
     if (length(valid_measurements) > 1) {
       signal_var <- stats::var(valid_measurements)
       # Scale base_Q based on both variance and rate, but more conservative
@@ -310,7 +310,7 @@ filter_kalman_irregular <- function(
   }
 
   if (is.null(R)) {
-    # If we have enough measurements for local differences
+    # If we have enough x for local differences
     if (length(valid_measurements) > 1) {
       # Use both local differences and overall variance to estimate noise
       local_diff_var <- mean(diff(valid_measurements)^2) / 2
@@ -339,7 +339,7 @@ filter_kalman_irregular <- function(
     ))
   }
 
-  n <- length(measurements)
+  n <- length(x)
   filtered <- numeric(n)
 
   # Initialize state
@@ -360,9 +360,9 @@ filter_kalman_irregular <- function(
     x_hat_minus <- x_hat
     P_minus <- P + Q
 
-    if (!is.na(measurements[i])) {
+    if (!is.na(x[i])) {
       K <- P_minus / (P_minus + R)
-      x_hat <- x_hat_minus + K * (measurements[i] - x_hat_minus)
+      x_hat <- x_hat_minus + K * (x[i] - x_hat_minus)
       P <- (1 - K) * P_minus
       last_time <- times[i]
     } else {
@@ -390,9 +390,9 @@ filter_kalman_irregular <- function(
       time = regular_times,
       values = regular_filtered,
       original_time = times,
-      original_values = restore_na(filtered, is.na(measurements), keep_na)
+      original_values = restore_na(filtered, is.na(x), keep_na)
     ))
   } else {
-    return(restore_na(filtered, is.na(measurements), keep_na))
+    return(restore_na(filtered, is.na(x), keep_na))
   }
 }

--- a/R/filter_na_confidence.R
+++ b/R/filter_na_confidence.R
@@ -70,6 +70,6 @@ filter_na_confidence <- function(data, threshold = 0.6) {
   # Filter confidence column
   data |>
     dplyr::mutate(
-      confidence = filter_na_range(.data$confidence, min = threshold)
+      confidence = filter_na_range(.data$confidence, min_value = threshold)
     )
 }

--- a/R/filter_na_range.R
+++ b/R/filter_na_range.R
@@ -4,39 +4,41 @@
 #' with NA. Values already NA in the input remain NA.
 #'
 #' @param x A numeric vector to filter
-#' @param min Minimum value (inclusive). Values below this become NA.
+#' @param min_value Minimum value (inclusive). Values below this become NA.
 #'   Default is -Inf (no lower bound).
-#' @param max Maximum value (inclusive). Values above this become NA.
+#' @param max_value Maximum value (inclusive). Values above this become NA.
 #'   Default is Inf (no upper bound).
 #'
 #' @return A numeric vector the same length as `x` with out-of-range values
 #'   replaced by NA
 #'
 #' @examples
-#' filter_na_range(c(1, 5, 10, 15), min = 3, max = 12)
+#' filter_na_range(c(1, 5, 10, 15), min_value = 3, max_value = 12)
 #' # Returns: c(NA, 5, 10, NA)
 #'
-#' filter_na_range(c(1, NA, 10), min = 5)
+#' filter_na_range(c(1, NA, 10), min_value = 5)
 #' # Returns: c(NA, NA, 10)
 #' @export
-filter_na_range <- function(x, min = -Inf, max = Inf) {
+filter_na_range <- function(x, min_value = -Inf, max_value = Inf) {
   # Input validation
   if (!is.numeric(x)) {
     cli::cli_abort("{.arg x} must be numeric.")
   }
-  if (!is.numeric(min) || length(min) != 1 || is.na(min)) {
-    cli::cli_abort("{.arg min} must be a single numeric value.")
+  if (!is.numeric(min_value) || length(min_value) != 1 || is.na(min_value)) {
+    cli::cli_abort("{.arg min_value} must be a single numeric value.")
   }
-  if (!is.numeric(max) || length(max) != 1 || is.na(max)) {
-    cli::cli_abort("{.arg max} must be a single numeric value.")
+  if (!is.numeric(max_value) || length(max_value) != 1 || is.na(max_value)) {
+    cli::cli_abort("{.arg max_value} must be a single numeric value.")
   }
-  if (min > max) {
-    cli::cli_abort("{.arg min} must be less than or equal to {.arg max}.")
+  if (min_value > max_value) {
+    cli::cli_abort(
+      "{.arg min_value} must be less than or equal to {.arg max_value}."
+    )
   }
 
   dplyr::case_when(
-    x < min ~ NA,
-    x > max ~ NA,
+    x < min_value ~ NA,
+    x > max_value ~ NA,
     .default = x
   )
 }

--- a/R/filter_sgolay.R
+++ b/R/filter_sgolay.R
@@ -7,7 +7,7 @@
 #' @param x Numeric vector containing the movement data to be filtered
 #' @param sampling_rate Sampling rate of the data in Hz. Must match your data
 #'        collection rate (e.g., 60 for 60 FPS motion capture).
-#' @param window_size Window size in samples (must be odd). Controls the amount of
+#' @param window_width Window size in samples (must be odd). Controls the amount of
 #'        smoothing. Larger windows give more smoothing but may over-attenuate
 #'        genuine movement features. Default is automatically calculated as
 #'        sampling_rate/10 (rounded up to nearest odd number).
@@ -31,24 +31,24 @@
 #' edge convention.
 #'
 #' Parameter Selection Guidelines:
-#' * window_size:
+#' * window_width:
 #'   - For 60 FPS: 5-15 frames (83-250ms) for quick movements, 15-31 for slow movements
 #'   - For 120 FPS: 7-21 frames (58-175ms) for quick movements, 21-51 for slow movements
 #'   - For 500 FPS: 25-75 frames (50-150ms) for quick movements, 75-151 for slow movements
-#'   The default window_size = sampling_rate/10 works well for typical human movement.
+#'   The default window_width = sampling_rate/10 works well for typical human movement.
 #'
 #' * order:
 #'   - order=2: Smooth movements, position analysis
 #'   - order=3: Most movement analysis (default)
 #'   - order=4: Quick movements, sports analysis
 #'   - order=5: Very quick movements, impact analysis
-#'   Note: order must be less than window_size
+#'   Note: order must be less than window_width
 #'
 #' Common values by application:
-#' * Gait analysis (60 FPS): window_size=15, order=3
-#' * Sports biomechanics (120 FPS): window_size=21, order=4
-#' * Impact analysis (500 FPS): window_size=51, order=4
-#' * Posture analysis (60 FPS): window_size=31, order=2
+#' * Gait analysis (60 FPS): window_width=15, order=3
+#' * Sports biomechanics (120 FPS): window_width=21, order=4
+#' * Impact analysis (500 FPS): window_width=51, order=4
+#' * Posture analysis (60 FPS): window_width=31, order=2
 #'
 #' @return Numeric vector containing the filtered movement data
 #'
@@ -62,11 +62,11 @@
 #'
 #' # Adjusting parameters for quick movements
 #' filtered_quick <- filter_sgolay(x, sampling_rate = 60,
-#'                                window_size = 11, order = 4)
+#'                                window_width = 11, order = 4)
 #'
 #' # High-speed camera data (500 FPS) with larger window
 #' filtered_high <- filter_sgolay(x, sampling_rate = 500,
-#'                               window_size = 51, order = 3)
+#'                               window_width = 51, order = 3)
 #'
 #' @seealso
 #' \code{\link{filter_lowpass}} for frequency-based filtering
@@ -80,7 +80,7 @@
 filter_sgolay <- function(
   x,
   sampling_rate,
-  window_size = ceiling(sampling_rate / 10) * 2 + 1,
+  window_width = ceiling(sampling_rate / 10) * 2 + 1,
   order = 3,
   na_action = "linear",
   keep_na = TRUE,
@@ -96,19 +96,19 @@ filter_sgolay <- function(
   if (!is.numeric(sampling_rate) || sampling_rate <= 0) {
     cli::cli_abort("Sampling rate must be a positive number")
   }
-  if (window_size %% 2 != 1) {
+  if (window_width %% 2 != 1) {
     cli::cli_abort("Window size must be odd")
   }
-  if (window_size > length(x)) {
+  if (window_width > length(x)) {
     cli::cli_abort("Window size cannot be larger than data length")
   }
-  if (order >= window_size) {
+  if (order >= window_width) {
     cli::cli_abort("Polynomial order must be less than window size")
   }
   ensure_keep_na(keep_na)
 
   prepared <- prepare_na(x, na_action, list(...))
-  result <- signal::sgolayfilt(prepared$x, p = order, n = window_size)
+  result <- signal::sgolayfilt(prepared$x, p = order, n = window_width)
 
   restore_na(result, prepared$na_positions, keep_na)
 }

--- a/R/find_extrema.R
+++ b/R/find_extrema.R
@@ -14,7 +14,7 @@
 #'   * "first": First point of plateau is peak
 #'   * "last": Last point of plateau is peak
 #'   * "all": All points in plateau are peaks
-#' @param window_size Integer specifying the size of the window to use for peak detection (default: 3).
+#' @param window_width Integer specifying the size of the window to use for peak detection (default: 3).
 #'   Must be odd and >= 3. Larger values detect peaks over wider ranges.
 #'
 #' @return A logical vector of the same length as the input where:
@@ -23,12 +23,12 @@
 #' * `NA` indicates peak status could not be determined due to missing data
 #'
 #' @details
-#' The function uses a sliding window algorithm for peak detection (window size specified by window_size parameter),
+#' The function uses a sliding window algorithm for peak detection (window size specified by window_width parameter),
 #' combined with a region-based prominence calculation method similar to that described in Palshikar (2009).
 #'
 #' # Peak Detection
-#' A point is considered a peak if it is the highest point within its window (default window_size of 3
-#' compares each point with its immediate neighbors). The first and last (window_size-1)/2 points in the
+#' A point is considered a peak if it is the highest point within its window (default window_width of 3
+#' compares each point with its immediate neighbors). The first and last (window_width-1)/2 points in the
 #' series cannot be peaks and are marked as NA. Larger window sizes will identify peaks that dominate over
 #' a wider range, typically resulting in fewer peaks being detected.
 #'
@@ -55,7 +55,7 @@
 #' * If a point is NA, it cannot be a peak (returns NA)
 #' * If any point in the window is NA, peak status cannot be determined (returns NA)
 #' * For prominence calculations, stretches of NAs are handled appropriately
-#' * A minimum of window_size points is required; shorter series return all NAs
+#' * A minimum of window_width points is required; shorter series return all NAs
 #'
 #' @references
 #' Palshikar, G. (2009). Simple Algorithms for Peak Detection in Time-Series.
@@ -67,15 +67,15 @@
 #' find_peaks(x)
 #'
 #' # With larger window size
-#' find_peaks(x, window_size = 5)  # More stringent peak detection
+#' find_peaks(x, window_width = 5)  # More stringent peak detection
 #'
 #' # With minimum height
-#' find_peaks(x, min_height = 4, window_size = 3)
+#' find_peaks(x, min_height = 4, window_width = 3)
 #'
 #' # With plateau handling
 #' x <- c(1, 3, 3, 3, 2, 4, 4, 1)
-#' find_peaks(x, plateau_handling = "middle", window_size = 3)  # Middle of plateaus
-#' find_peaks(x, plateau_handling = "all", window_size = 5)     # All plateau points
+#' find_peaks(x, plateau_handling = "middle", window_width = 3)  # Middle of plateaus
+#' find_peaks(x, plateau_handling = "all", window_width = 5)     # All plateau points
 #'
 #' # With missing values
 #' x <- c(1, 3, NA, 6, 4, NA, 2)
@@ -87,17 +87,17 @@
 #'   time = 1:10,
 #'   value = c(1, 3, 7, 4, 2, 6, 5, 8, 4, 2)
 #' ) %>%
-#'   mutate(peaks = find_peaks(value, window_size = 3))
+#'   mutate(peaks = find_peaks(value, window_width = 3))
 #'
 #' @seealso
 #' * \code{\link{find_troughs}} for finding local minima
 #'
 #' @note
 #' * The function is optimized for use with dplyr's mutate
-#' * For noisy data, consider using a larger window_size or smoothing the series before peak detection
+#' * For noisy data, consider using a larger window_width or smoothing the series before peak detection
 #' * Adjust min_height and min_prominence to filter out unwanted peaks
 #' * Choose plateau_handling based on your specific needs
-#' * Larger window_size values result in more stringent peak detection
+#' * Larger window_width values result in more stringent peak detection
 #'
 #' @export
 find_peaks <- function(
@@ -105,7 +105,7 @@ find_peaks <- function(
   min_height = -Inf,
   min_prominence = 0,
   plateau_handling = c("strict", "middle", "first", "last", "all"),
-  window_size = 3
+  window_width = 3
 ) {
   plateau_handling <- match.arg(plateau_handling)
   find_extrema(
@@ -114,7 +114,7 @@ find_peaks <- function(
     min_prominence,
     plateau_handling,
     "peak",
-    window_size
+    window_width
   )
 }
 
@@ -134,7 +134,7 @@ find_peaks <- function(
 #'   * "first": First point of plateau is trough
 #'   * "last": Last point of plateau is trough
 #'   * "all": All points in plateau are troughs
-#' @param window_size Integer specifying the size of the window to use for trough detection (default: 3).
+#' @param window_width Integer specifying the size of the window to use for trough detection (default: 3).
 #'   Must be odd and >= 3. Larger values detect troughs over wider ranges.
 #'
 #' @return A logical vector of the same length as the input where:
@@ -143,12 +143,12 @@ find_peaks <- function(
 #' * `NA` indicates trough status could not be determined due to missing data
 #'
 #' @details
-#' The function uses a sliding window algorithm for trough detection (window size specified by window_size parameter),
+#' The function uses a sliding window algorithm for trough detection (window size specified by window_width parameter),
 #' combined with a region-based prominence calculation method similar to that described in Palshikar (2009).
 #'
 #' # Trough Detection
-#' A point is considered a trough if it is the lowest point within its window (default window_size of 3
-#' compares each point with its immediate neighbors). The first and last (window_size-1)/2 points in the
+#' A point is considered a trough if it is the lowest point within its window (default window_width of 3
+#' compares each point with its immediate neighbors). The first and last (window_width-1)/2 points in the
 #' series cannot be troughs and are marked as NA. Larger window sizes will identify troughs that dominate over
 #' a wider range, typically resulting in fewer troughs being detected.
 #'
@@ -175,7 +175,7 @@ find_peaks <- function(
 #' * If a point is NA, it cannot be a trough (returns NA)
 #' * If any point in the window is NA, trough status cannot be determined (returns NA)
 #' * For prominence calculations, stretches of NAs are handled appropriately
-#' * A minimum of window_size points is required; shorter series return all NAs
+#' * A minimum of window_width points is required; shorter series return all NAs
 #'
 #' @references
 #' Palshikar, G. (2009). Simple Algorithms for Peak Detection in Time-Series.
@@ -187,15 +187,15 @@ find_peaks <- function(
 #' find_troughs(x)
 #'
 #' # With larger window size
-#' find_troughs(x, window_size = 5)  # More stringent trough detection
+#' find_troughs(x, window_width = 5)  # More stringent trough detection
 #'
 #' # With maximum height
-#' find_troughs(x, max_height = 3, window_size = 3)
+#' find_troughs(x, max_height = 3, window_width = 3)
 #'
 #' # With plateau handling
 #' x <- c(5, 2, 2, 2, 3, 1, 1, 4)
-#' find_troughs(x, plateau_handling = "middle", window_size = 3)  # Middle of plateaus
-#' find_troughs(x, plateau_handling = "all", window_size = 5)     # All plateau points
+#' find_troughs(x, plateau_handling = "middle", window_width = 3)  # Middle of plateaus
+#' find_troughs(x, plateau_handling = "all", window_width = 5)     # All plateau points
 #'
 #' # With missing values
 #' x <- c(5, 3, NA, 1, 4, NA, 5)
@@ -207,17 +207,17 @@ find_peaks <- function(
 #'   time = 1:10,
 #'   value = c(5, 3, 1, 4, 2, 1, 3, 0, 4, 5)
 #' ) %>%
-#'   mutate(troughs = find_troughs(value, window_size = 3))
+#'   mutate(troughs = find_troughs(value, window_width = 3))
 #'
 #' @seealso
 #' * \code{\link{find_peaks}} for finding local maxima
 #'
 #' @note
 #' * The function is optimized for use with dplyr's mutate
-#' * For noisy data, consider using a larger window_size or smoothing the series before trough detection
+#' * For noisy data, consider using a larger window_width or smoothing the series before trough detection
 #' * Adjust max_height and min_prominence to filter out unwanted troughs
 #' * Choose plateau_handling based on your specific needs
-#' * Larger window_size values result in more stringent trough detection
+#' * Larger window_width values result in more stringent trough detection
 #'
 #' @export
 find_troughs <- function(
@@ -225,7 +225,7 @@ find_troughs <- function(
   max_height = Inf,
   min_prominence = 0,
   plateau_handling = c("strict", "middle", "first", "last", "all"),
-  window_size = 3
+  window_width = 3
 ) {
   plateau_handling <- match.arg(plateau_handling)
   find_extrema(
@@ -234,7 +234,7 @@ find_troughs <- function(
     min_prominence,
     plateau_handling,
     "trough",
-    window_size
+    window_width
   )
 }
 
@@ -246,14 +246,14 @@ find_extrema <- function(
   min_prominence,
   plateau_handling,
   type,
-  window_size
+  window_width
 ) {
   # Input validation
   if (!is.numeric(x) && !all(is.na(x))) {
     stop("Input must be numeric or NA")
   }
-  if (!is.numeric(window_size) || window_size < 3 || window_size %% 2 == 0) {
-    stop("window_size must be an odd integer >= 3")
+  if (!is.numeric(window_width) || window_width < 3 || window_width %% 2 == 0) {
+    stop("window_width must be an odd integer >= 3")
   }
 
   # Initialize result vector
@@ -261,12 +261,12 @@ find_extrema <- function(
   is_extremum <- rep(FALSE, n)
 
   # Handle special cases
-  if (n < window_size) {
+  if (n < window_width) {
     return(rep(NA, n))
   }
 
   # Edge points can't be extrema
-  half_window <- floor(window_size / 2)
+  half_window <- floor(window_width / 2)
   is_extremum[1:half_window] <- NA
   is_extremum[(n - half_window + 1):n] <- NA
 
@@ -385,7 +385,7 @@ find_extrema <- function(
   # indices (NAs are dropped), so is_extremum[i] is TRUE here.
   if (min_prominence > 0) {
     for (i in which(is_extremum)) {
-      # Calculate prominence using window_size for initial search
+      # Calculate prominence using window_width for initial search
       left_idx <- max(1, i - half_window)
       right_idx <- min(n, i + half_window)
 

--- a/man/filter_kalman.Rd
+++ b/man/filter_kalman.Rd
@@ -5,7 +5,7 @@
 \title{Kalman Filter for Regular Time Series}
 \usage{
 filter_kalman(
-  measurements,
+  x,
   sampling_rate,
   base_Q = NULL,
   R = NULL,
@@ -15,7 +15,7 @@ filter_kalman(
 )
 }
 \arguments{
-\item{measurements}{Numeric vector containing the measurements to be filtered.}
+\item{x}{Numeric vector of measurements to be filtered.}
 
 \item{sampling_rate}{Numeric value specifying the sampling rate in Hz (frames per second).}
 
@@ -30,14 +30,14 @@ Represents the noise level in your measurements.}
 \item{initial_P}{Optional. Initial state uncertainty. If NULL, calculated based on sampling_rate.}
 
 \item{keep_na}{Logical. If \code{TRUE}, positions that were \code{NA} in
-\code{measurements} are \code{NA} in the output. Defaults to \code{FALSE}, unlike the
+\code{x} are \code{NA} in the output. Defaults to \code{FALSE}, unlike the
 rest of the filter family: a Kalman filter's predict step is designed
 to carry the state estimate through missing observations, so inferring
 across gaps is the intended behaviour rather than an accident. Set
 \code{TRUE} when you want gaps left as gaps.}
 }
 \value{
-A numeric vector of the same length as measurements containing the filtered values.
+A numeric vector of the same length as x containing the filtered values.
 }
 \description{
 Implements a Kalman filter for regularly sampled time series data with automatic
@@ -49,12 +49,12 @@ The function implements a simple Kalman filter with a constant position model.
 When parameters are not explicitly provided, they are automatically configured based
 on the sampling rate:
 \itemize{
-\item \code{base_Q} defaults to \code{var(measurements) / sampling_rate} (so the
+\item \code{base_Q} defaults to \code{var(x) / sampling_rate} (so the
 per-step process noise \code{Q = base_Q / sampling_rate} shrinks at higher
 sampling rates, where consecutive samples are closer together).
 \item \code{R} defaults to \code{min(mean(diff(x)^2) / 2, var(x) / 4)} if there are
 enough observations, else \code{0.1}.
-\item \code{initial_P} defaults to \code{var(measurements)} if there are enough
+\item \code{initial_P} defaults to \code{var(x)} if there are enough
 observations, else \code{1}.
 }
 
@@ -71,11 +71,11 @@ Parameter selection guidelines:
 }
 \examples{
 # Basic usage with 60 Hz data
-measurements <- c(1, 1.1, NA, 0.9, 1.2, NA, 0.8, 1.1)
-filtered <- filter_kalman(measurements, sampling_rate = 60)
+x <- c(1, 1.1, NA, 0.9, 1.2, NA, 0.8, 1.1)
+filtered <- filter_kalman(x, sampling_rate = 60)
 
 # Custom parameters for more aggressive filtering
-filtered_custom <- filter_kalman(measurements,
+filtered_custom <- filter_kalman(x,
                                 sampling_rate = 60,
                                 base_Q = 0.001,
                                 R = 0.2)

--- a/man/filter_kalman_irregular.Rd
+++ b/man/filter_kalman_irregular.Rd
@@ -5,7 +5,7 @@
 \title{Kalman Filter for Irregular Time Series with Optional Resampling}
 \usage{
 filter_kalman_irregular(
-  measurements,
+  x,
   times,
   base_Q = NULL,
   R = NULL,
@@ -17,9 +17,9 @@ filter_kalman_irregular(
 )
 }
 \arguments{
-\item{measurements}{Numeric vector containing the measurements to be filtered.}
+\item{x}{Numeric vector of measurements to be filtered.}
 
-\item{times}{Numeric vector of timestamps corresponding to measurements.}
+\item{times}{Numeric vector of timestamps corresponding to x.}
 
 \item{base_Q}{Optional. Base process variance per second. If NULL, automatically calculated.}
 
@@ -34,7 +34,7 @@ filter_kalman_irregular(
 \item{resample_freq}{Numeric. Desired sampling frequency in Hz for resampling (required if resample=TRUE).}
 
 \item{keep_na}{Logical. If \code{TRUE}, positions that were \code{NA} in
-\code{measurements} are \code{NA} in the values reported on the original
+\code{x} are \code{NA} in the values reported on the original
 timestamps. Defaults to \code{FALSE}, for the reason given in
 \code{\link[=filter_kalman]{filter_kalman()}}. When \code{resample = TRUE} this applies to
 \code{original_values} only — the resampled \code{values} sit on a different
@@ -88,24 +88,24 @@ Parameter selection guidelines:
 \item base_Q controls the expected rate of change per second
 \item R should reflect your measurement noise level
 \item For slow-changing signals, reduce base_Q
-\item For noisy measurements, increase R
+\item For noisy x, increase R
 }
 }
 \examples{
 # Example with irregular sampling
-measurements <- c(1, 1.1, NA, 0.9, 1.2, NA, 0.8, 1.1)
+x <- c(1, 1.1, NA, 0.9, 1.2, NA, 0.8, 1.1)
 times <- c(0, 0.1, 0.3, 0.35, 0.5, 0.8, 0.81, 1.0)
 
 # Basic filtering with irregular samples
-filtered <- filter_kalman_irregular(measurements, times)
+filtered <- filter_kalman_irregular(x, times)
 
 # Filtering with resampling to 50 Hz
-filtered_resampled <- filter_kalman_irregular(measurements, times,
+filtered_resampled <- filter_kalman_irregular(x, times,
                                              resample = TRUE,
                                              resample_freq = 50)
 
 # Plot results
-plot(times, measurements, type="p", col="blue")
+plot(times, x, type="p", col="blue")
 lines(filtered_resampled$time, filtered_resampled$values, col="red")
 
 }

--- a/man/filter_na_range.Rd
+++ b/man/filter_na_range.Rd
@@ -4,15 +4,15 @@
 \alias{filter_na_range}
 \title{Filter values outside a range to NA}
 \usage{
-filter_na_range(x, min = -Inf, max = Inf)
+filter_na_range(x, min_value = -Inf, max_value = Inf)
 }
 \arguments{
 \item{x}{A numeric vector to filter}
 
-\item{min}{Minimum value (inclusive). Values below this become NA.
+\item{min_value}{Minimum value (inclusive). Values below this become NA.
 Default is -Inf (no lower bound).}
 
-\item{max}{Maximum value (inclusive). Values above this become NA.
+\item{max_value}{Maximum value (inclusive). Values above this become NA.
 Default is Inf (no upper bound).}
 }
 \value{
@@ -24,9 +24,9 @@ Replaces values in a numeric vector that fall outside the specified range
 with NA. Values already NA in the input remain NA.
 }
 \examples{
-filter_na_range(c(1, 5, 10, 15), min = 3, max = 12)
+filter_na_range(c(1, 5, 10, 15), min_value = 3, max_value = 12)
 # Returns: c(NA, 5, 10, NA)
 
-filter_na_range(c(1, NA, 10), min = 5)
+filter_na_range(c(1, NA, 10), min_value = 5)
 # Returns: c(NA, NA, 10)
 }

--- a/man/filter_sgolay.Rd
+++ b/man/filter_sgolay.Rd
@@ -7,7 +7,7 @@
 filter_sgolay(
   x,
   sampling_rate,
-  window_size = ceiling(sampling_rate/10) * 2 + 1,
+  window_width = ceiling(sampling_rate/10) * 2 + 1,
   order = 3,
   na_action = "linear",
   keep_na = TRUE,
@@ -20,7 +20,7 @@ filter_sgolay(
 \item{sampling_rate}{Sampling rate of the data in Hz. Must match your data
 collection rate (e.g., 60 for 60 FPS motion capture).}
 
-\item{window_size}{Window size in samples (must be odd). Controls the amount of
+\item{window_width}{Window size in samples (must be odd). Controls the amount of
 smoothing. Larger windows give more smoothing but may over-attenuate
 genuine movement features. Default is automatically calculated as
 sampling_rate/10 (rounded up to nearest odd number).}
@@ -68,12 +68,12 @@ edge convention.
 
 Parameter Selection Guidelines:
 \itemize{
-\item window_size:
+\item window_width:
 \itemize{
 \item For 60 FPS: 5-15 frames (83-250ms) for quick movements, 15-31 for slow movements
 \item For 120 FPS: 7-21 frames (58-175ms) for quick movements, 21-51 for slow movements
 \item For 500 FPS: 25-75 frames (50-150ms) for quick movements, 75-151 for slow movements
-The default window_size = sampling_rate/10 works well for typical human movement.
+The default window_width = sampling_rate/10 works well for typical human movement.
 }
 \item order:
 \itemize{
@@ -81,16 +81,16 @@ The default window_size = sampling_rate/10 works well for typical human movement
 \item order=3: Most movement analysis (default)
 \item order=4: Quick movements, sports analysis
 \item order=5: Very quick movements, impact analysis
-Note: order must be less than window_size
+Note: order must be less than window_width
 }
 }
 
 Common values by application:
 \itemize{
-\item Gait analysis (60 FPS): window_size=15, order=3
-\item Sports biomechanics (120 FPS): window_size=21, order=4
-\item Impact analysis (500 FPS): window_size=51, order=4
-\item Posture analysis (60 FPS): window_size=31, order=2
+\item Gait analysis (60 FPS): window_width=15, order=3
+\item Sports biomechanics (120 FPS): window_width=21, order=4
+\item Impact analysis (500 FPS): window_width=51, order=4
+\item Posture analysis (60 FPS): window_width=31, order=2
 }
 }
 \examples{
@@ -103,11 +103,11 @@ filtered <- filter_sgolay(x, sampling_rate = 60)
 
 # Adjusting parameters for quick movements
 filtered_quick <- filter_sgolay(x, sampling_rate = 60,
-                               window_size = 11, order = 4)
+                               window_width = 11, order = 4)
 
 # High-speed camera data (500 FPS) with larger window
 filtered_high <- filter_sgolay(x, sampling_rate = 500,
-                              window_size = 51, order = 3)
+                              window_width = 51, order = 3)
 
 }
 \references{

--- a/man/find_peaks.Rd
+++ b/man/find_peaks.Rd
@@ -9,7 +9,7 @@ find_peaks(
   min_height = -Inf,
   min_prominence = 0,
   plateau_handling = c("strict", "middle", "first", "last", "all"),
-  window_size = 3
+  window_width = 3
 )
 }
 \arguments{
@@ -28,7 +28,7 @@ find_peaks(
 \item "all": All points in plateau are peaks
 }}
 
-\item{window_size}{Integer specifying the size of the window to use for peak detection (default: 3).
+\item{window_width}{Integer specifying the size of the window to use for peak detection (default: 3).
 Must be odd and >= 3. Larger values detect peaks over wider ranges.}
 }
 \value{
@@ -45,21 +45,21 @@ height and prominence. The function handles missing values (NA) appropriately an
 with dplyr's mutate. Includes flexible handling of plateaus and adjustable window size for peak detection.
 }
 \details{
-The function uses a sliding window algorithm for peak detection (window size specified by window_size parameter),
+The function uses a sliding window algorithm for peak detection (window size specified by window_width parameter),
 combined with a region-based prominence calculation method similar to that described in Palshikar (2009).
 }
 \note{
 \itemize{
 \item The function is optimized for use with dplyr's mutate
-\item For noisy data, consider using a larger window_size or smoothing the series before peak detection
+\item For noisy data, consider using a larger window_width or smoothing the series before peak detection
 \item Adjust min_height and min_prominence to filter out unwanted peaks
 \item Choose plateau_handling based on your specific needs
-\item Larger window_size values result in more stringent peak detection
+\item Larger window_width values result in more stringent peak detection
 }
 }
 \section{Peak Detection}{
-A point is considered a peak if it is the highest point within its window (default window_size of 3
-compares each point with its immediate neighbors). The first and last (window_size-1)/2 points in the
+A point is considered a peak if it is the highest point within its window (default window_width of 3
+compares each point with its immediate neighbors). The first and last (window_width-1)/2 points in the
 series cannot be peaks and are marked as NA. Larger window sizes will identify peaks that dominate over
 a wider range, typically resulting in fewer peaks being detected.
 }
@@ -91,7 +91,7 @@ The function uses the following rules for handling NAs:
 \item If a point is NA, it cannot be a peak (returns NA)
 \item If any point in the window is NA, peak status cannot be determined (returns NA)
 \item For prominence calculations, stretches of NAs are handled appropriately
-\item A minimum of window_size points is required; shorter series return all NAs
+\item A minimum of window_width points is required; shorter series return all NAs
 }
 }
 
@@ -101,15 +101,15 @@ x <- c(1, 3, 2, 6, 4, 5, 2)
 find_peaks(x)
 
 # With larger window size
-find_peaks(x, window_size = 5)  # More stringent peak detection
+find_peaks(x, window_width = 5)  # More stringent peak detection
 
 # With minimum height
-find_peaks(x, min_height = 4, window_size = 3)
+find_peaks(x, min_height = 4, window_width = 3)
 
 # With plateau handling
 x <- c(1, 3, 3, 3, 2, 4, 4, 1)
-find_peaks(x, plateau_handling = "middle", window_size = 3)  # Middle of plateaus
-find_peaks(x, plateau_handling = "all", window_size = 5)     # All plateau points
+find_peaks(x, plateau_handling = "middle", window_width = 3)  # Middle of plateaus
+find_peaks(x, plateau_handling = "all", window_width = 5)     # All plateau points
 
 # With missing values
 x <- c(1, 3, NA, 6, 4, NA, 2)
@@ -121,7 +121,7 @@ data_frame(
   time = 1:10,
   value = c(1, 3, 7, 4, 2, 6, 5, 8, 4, 2)
 ) \%>\%
-  mutate(peaks = find_peaks(value, window_size = 3))
+  mutate(peaks = find_peaks(value, window_width = 3))
 
 }
 \references{

--- a/man/find_troughs.Rd
+++ b/man/find_troughs.Rd
@@ -9,7 +9,7 @@ find_troughs(
   max_height = Inf,
   min_prominence = 0,
   plateau_handling = c("strict", "middle", "first", "last", "all"),
-  window_size = 3
+  window_width = 3
 )
 }
 \arguments{
@@ -28,7 +28,7 @@ find_troughs(
 \item "all": All points in plateau are troughs
 }}
 
-\item{window_size}{Integer specifying the size of the window to use for trough detection (default: 3).
+\item{window_width}{Integer specifying the size of the window to use for trough detection (default: 3).
 Must be odd and >= 3. Larger values detect troughs over wider ranges.}
 }
 \value{
@@ -45,21 +45,21 @@ height and prominence. The function handles missing values (NA) appropriately an
 with dplyr's mutate. Includes flexible handling of plateaus and adjustable window size for trough detection.
 }
 \details{
-The function uses a sliding window algorithm for trough detection (window size specified by window_size parameter),
+The function uses a sliding window algorithm for trough detection (window size specified by window_width parameter),
 combined with a region-based prominence calculation method similar to that described in Palshikar (2009).
 }
 \note{
 \itemize{
 \item The function is optimized for use with dplyr's mutate
-\item For noisy data, consider using a larger window_size or smoothing the series before trough detection
+\item For noisy data, consider using a larger window_width or smoothing the series before trough detection
 \item Adjust max_height and min_prominence to filter out unwanted troughs
 \item Choose plateau_handling based on your specific needs
-\item Larger window_size values result in more stringent trough detection
+\item Larger window_width values result in more stringent trough detection
 }
 }
 \section{Trough Detection}{
-A point is considered a trough if it is the lowest point within its window (default window_size of 3
-compares each point with its immediate neighbors). The first and last (window_size-1)/2 points in the
+A point is considered a trough if it is the lowest point within its window (default window_width of 3
+compares each point with its immediate neighbors). The first and last (window_width-1)/2 points in the
 series cannot be troughs and are marked as NA. Larger window sizes will identify troughs that dominate over
 a wider range, typically resulting in fewer troughs being detected.
 }
@@ -91,7 +91,7 @@ The function uses the following rules for handling NAs:
 \item If a point is NA, it cannot be a trough (returns NA)
 \item If any point in the window is NA, trough status cannot be determined (returns NA)
 \item For prominence calculations, stretches of NAs are handled appropriately
-\item A minimum of window_size points is required; shorter series return all NAs
+\item A minimum of window_width points is required; shorter series return all NAs
 }
 }
 
@@ -101,15 +101,15 @@ x <- c(5, 3, 4, 1, 4, 2, 5)
 find_troughs(x)
 
 # With larger window size
-find_troughs(x, window_size = 5)  # More stringent trough detection
+find_troughs(x, window_width = 5)  # More stringent trough detection
 
 # With maximum height
-find_troughs(x, max_height = 3, window_size = 3)
+find_troughs(x, max_height = 3, window_width = 3)
 
 # With plateau handling
 x <- c(5, 2, 2, 2, 3, 1, 1, 4)
-find_troughs(x, plateau_handling = "middle", window_size = 3)  # Middle of plateaus
-find_troughs(x, plateau_handling = "all", window_size = 5)     # All plateau points
+find_troughs(x, plateau_handling = "middle", window_width = 3)  # Middle of plateaus
+find_troughs(x, plateau_handling = "all", window_width = 5)     # All plateau points
 
 # With missing values
 x <- c(5, 3, NA, 1, 4, NA, 5)
@@ -121,7 +121,7 @@ data_frame(
   time = 1:10,
   value = c(5, 3, 1, 4, 2, 1, 3, 0, 4, 5)
 ) \%>\%
-  mutate(troughs = find_troughs(value, window_size = 3))
+  mutate(troughs = find_troughs(value, window_width = 3))
 
 }
 \references{

--- a/tests/testthat/test-filter_kalman.R
+++ b/tests/testthat/test-filter_kalman.R
@@ -4,8 +4,8 @@ library(testthat)
 generate_sine_data <- function(n = 100, freq = 0.1, noise_sd = 0.1) {
   t <- seq(0, n - 1)
   true_signal <- sin(2 * pi * freq * t)
-  measurements <- true_signal + rnorm(n, 0, noise_sd)
-  return(list(time = t, measurements = measurements, true_signal = true_signal))
+  x <- true_signal + rnorm(n, 0, noise_sd)
+  return(list(time = t, x = x, true_signal = true_signal))
 }
 
 test_that("First update matches the standard scalar Kalman equations", {
@@ -14,7 +14,7 @@ test_that("First update matches the standard scalar Kalman equations", {
   # K = 1.1 / (1.1 + 0.5) = 0.6875
   # x_hat = 0 + 0.6875 * (2 - 0) = 1.375
   out <- filter_kalman(
-    measurements = 2,
+    x = 2,
     sampling_rate = 10,
     base_Q = 1.0,
     R = 0.5,
@@ -24,9 +24,9 @@ test_that("First update matches the standard scalar Kalman equations", {
   expect_equal(out[1], 1.375)
 })
 
-test_that("Huge R makes the filter ignore measurements", {
+test_that("Huge R makes the filter ignore x", {
   out <- filter_kalman(
-    measurements = c(10, 20, 30, 40, 50),
+    x = c(10, 20, 30, 40, 50),
     sampling_rate = 10,
     base_Q = 0,
     R = 1e12,
@@ -37,9 +37,9 @@ test_that("Huge R makes the filter ignore measurements", {
   expect_true(all(abs(out) < 1e-9))
 })
 
-test_that("Tiny R makes the filter track measurements", {
+test_that("Tiny R makes the filter track x", {
   out <- filter_kalman(
-    measurements = c(1, 2, 3, 4, 5),
+    x = c(1, 2, 3, 4, 5),
     sampling_rate = 10,
     base_Q = 0.5,
     R = 1e-8
@@ -219,13 +219,13 @@ test_that("filter_kalman_irregular accepts an explicit initial_state", {
 #   data <- generate_sine_data(n = 1000, freq = 0.05, noise_sd = 0.1)
 #
 #   # Regular sampling
-#   filtered_reg <- filter_kalman(data$measurements, sampling_rate = 1)
+#   filtered_reg <- filter_kalman(data$x, sampling_rate = 1)
 #   mse_reg <- mean((filtered_reg - data$true_signal)^2)
 #   noise_var <- 0.1^2
 #   expect_true(mse_reg < noise_var)
 #
 #   # Irregular sampling
-#   filtered_irreg <- filter_kalman_irregular(data$measurements, data$time)
+#   filtered_irreg <- filter_kalman_irregular(data$x, data$time)
 #   mse_irreg <- mean((filtered_irreg - data$true_signal)^2)
 #   expect_true(mse_irreg < noise_var)
 # })
@@ -237,13 +237,13 @@ test_that("Performance benchmarks", {
 
   # Regular sampling
   time_reg <- system.time({
-    filtered_reg <- filter_kalman(data$measurements, sampling_rate = 1)
+    filtered_reg <- filter_kalman(data$x, sampling_rate = 1)
   })
   expect_true(time_reg["elapsed"] < 1) # Should complete in under 1 second
 
   # Irregular sampling
   time_irreg <- system.time({
-    filtered_irreg <- filter_kalman_irregular(data$measurements, data$time)
+    filtered_irreg <- filter_kalman_irregular(data$x, data$time)
   })
   expect_true(time_irreg["elapsed"] < 1)
 })
@@ -275,7 +275,7 @@ test_that("Parameter sensitivity", {
   # Test different base_Q values
   q_values <- 10^seq(-6, 0, by = 2)
   filtered_q <- lapply(q_values, function(q) {
-    filter_kalman(data$measurements, sampling_rate = 1, base_Q = q)
+    filter_kalman(data$x, sampling_rate = 1, base_Q = q)
   })
 
   # Verify that larger Q leads to more responsive filtering
@@ -285,7 +285,7 @@ test_that("Parameter sensitivity", {
   # Test different R values
   r_values <- 10^seq(-6, 0, by = 2)
   filtered_r <- lapply(r_values, function(r) {
-    filter_kalman(data$measurements, sampling_rate = 1, R = r)
+    filter_kalman(data$x, sampling_rate = 1, R = r)
   })
 
   # Verify that larger R leads to more smoothing

--- a/tests/testthat/test-filter_sgolay.R
+++ b/tests/testthat/test-filter_sgolay.R
@@ -8,7 +8,7 @@ test_that("filter reproduces polynomials of degree <= order (defining property)"
     out <- filter_sgolay(
       x,
       sampling_rate = 60,
-      window_size = 11,
+      window_width = 11,
       order = max(deg, 2)
     )
     # Tolerance loosens with degree because the Vandermonde-like fit gets
@@ -54,17 +54,17 @@ test_that("parameter validation works", {
 
   # Invalid window size
   expect_error(
-    filter_sgolay(x, sampling_rate = 60, window_size = 4),
+    filter_sgolay(x, sampling_rate = 60, window_width = 4),
     "Window size must be odd"
   )
   expect_error(
-    filter_sgolay(x, sampling_rate = 60, window_size = 101),
+    filter_sgolay(x, sampling_rate = 60, window_width = 101),
     "Window size cannot be larger than data length"
   )
 
   # Invalid polynomial order
   expect_error(
-    filter_sgolay(x, sampling_rate = 60, window_size = 11, order = 11),
+    filter_sgolay(x, sampling_rate = 60, window_width = 11, order = 11),
     "Polynomial order must be less than window size"
   )
 })
@@ -115,8 +115,8 @@ test_that("window size affects smoothing appropriately", {
   x <- sin(2 * pi * 2 * t) + rnorm(length(t), 0, 0.1)
 
   # Test different window sizes
-  filtered_small <- filter_sgolay(x, sampling_rate = 60, window_size = 5)
-  filtered_large <- filter_sgolay(x, sampling_rate = 60, window_size = 21)
+  filtered_small <- filter_sgolay(x, sampling_rate = 60, window_width = 5)
+  filtered_large <- filter_sgolay(x, sampling_rate = 60, window_width = 21)
 
   # Larger window should result in smoother output
   expect_gt(var(diff(filtered_small)), var(diff(filtered_large)))
@@ -136,7 +136,7 @@ test_that("default parameters are reasonable", {
   explicit_result <- filter_sgolay(
     x,
     sampling_rate = 60,
-    window_size = expected_window
+    window_width = expected_window
   )
   expect_equal(default_result, explicit_result)
 })

--- a/tests/testthat/test-find_extrema.R
+++ b/tests/testthat/test-find_extrema.R
@@ -220,45 +220,45 @@ test_that("prominence works with plateaus", {
 test_that("window size parameter works correctly", {
   # Test case where wider window identifies fewer peaks
   x <- c(1, 3, 2, 4, 3, 5, 4, 6, 5, 7, 6)
-  peaks_w3 <- which(find_peaks(x, window_size = 3))
-  peaks_w5 <- which(find_peaks(x, window_size = 5))
+  peaks_w3 <- which(find_peaks(x, window_width = 3))
+  peaks_w5 <- which(find_peaks(x, window_width = 5))
   expect_true(length(peaks_w3) > length(peaks_w5))
 
   # Test window size validation
-  expect_error(find_peaks(1:10, window_size = 2)) # Too small
-  expect_error(find_peaks(1:10, window_size = 4)) # Even number
-  expect_error(find_peaks(1:10, window_size = "3")) # Not numeric
+  expect_error(find_peaks(1:10, window_width = 2)) # Too small
+  expect_error(find_peaks(1:10, window_width = 4)) # Even number
+  expect_error(find_peaks(1:10, window_width = "3")) # Not numeric
 
   # Test behavior with window size larger than data
   x_short <- 1:5
-  expect_equal(find_peaks(x_short, window_size = 7), rep(NA, 5))
+  expect_equal(find_peaks(x_short, window_width = 7), rep(NA, 5))
 
   # Test edge handling with different window sizes
   x <- c(1, 3, 2, 4, 2, 3, 1)
-  result_w3 <- find_peaks(x, window_size = 3)
-  result_w5 <- find_peaks(x, window_size = 5)
+  result_w3 <- find_peaks(x, window_width = 3)
+  result_w5 <- find_peaks(x, window_width = 5)
   expect_equal(sum(is.na(result_w3)), 2) # First and last points
   expect_equal(sum(is.na(result_w5)), 4) # Two points on each end
 
   # Test with noisy data
   set.seed(123)
   x <- sin(seq(0, 4 * pi, length.out = 100)) + rnorm(100, 0, 0.1)
-  peaks_w3 <- sum(find_peaks(x, window_size = 3), na.rm = TRUE)
-  peaks_w7 <- sum(find_peaks(x, window_size = 7), na.rm = TRUE)
-  peaks_w11 <- sum(find_peaks(x, window_size = 11), na.rm = TRUE)
+  peaks_w3 <- sum(find_peaks(x, window_width = 3), na.rm = TRUE)
+  peaks_w7 <- sum(find_peaks(x, window_width = 7), na.rm = TRUE)
+  peaks_w11 <- sum(find_peaks(x, window_width = 11), na.rm = TRUE)
   expect_true(peaks_w3 > peaks_w7)
   expect_true(peaks_w7 > peaks_w11)
 
   # Test plateau handling with different window sizes
   x <- c(1, 3, 3, 3, 2, 4, 4, 4, 2)
-  peaks_w3 <- which(find_peaks(x, window_size = 3, plateau_handling = "middle"))
-  peaks_w5 <- which(find_peaks(x, window_size = 5, plateau_handling = "middle"))
+  peaks_w3 <- which(find_peaks(x, window_width = 3, plateau_handling = "middle"))
+  peaks_w5 <- which(find_peaks(x, window_width = 5, plateau_handling = "middle"))
   expect_equal(peaks_w3, c(3, 7)) # Both plateaus are peaks
   expect_equal(peaks_w5, 7) # Only second plateau is peak
 
   # Test with NAs and different window sizes
   x <- c(1, 3, NA, 4, 2, 5, NA, 3, 1)
-  result_w3 <- find_peaks(x, window_size = 3)
-  result_w5 <- find_peaks(x, window_size = 5)
+  result_w3 <- find_peaks(x, window_width = 3)
+  result_w5 <- find_peaks(x, window_width = 5)
   expect_true(sum(is.na(result_w5)) > sum(is.na(result_w3)))
 })

--- a/tests/testthat/test-find_extrema.R
+++ b/tests/testthat/test-find_extrema.R
@@ -251,8 +251,16 @@ test_that("window size parameter works correctly", {
 
   # Test plateau handling with different window sizes
   x <- c(1, 3, 3, 3, 2, 4, 4, 4, 2)
-  peaks_w3 <- which(find_peaks(x, window_width = 3, plateau_handling = "middle"))
-  peaks_w5 <- which(find_peaks(x, window_width = 5, plateau_handling = "middle"))
+  peaks_w3 <- which(find_peaks(
+    x,
+    window_width = 3,
+    plateau_handling = "middle"
+  ))
+  peaks_w5 <- which(find_peaks(
+    x,
+    window_width = 5,
+    plateau_handling = "middle"
+  ))
   expect_equal(peaks_w3, c(3, 7)) # Both plateaus are peaks
   expect_equal(peaks_w5, 7) # Only second plateau is peak
 

--- a/tests/testthat/test-na_handling.R
+++ b/tests/testthat/test-na_handling.R
@@ -120,7 +120,7 @@ test_that("filter_kalman fills by default but honours keep_na = TRUE", {
 })
 
 test_that("every filter rejects an invalid keep_na", {
-  # Long enough that sgolay's derived window_size stays valid, so the
+  # Long enough that sgolay's derived window_width stays valid, so the
   # keep_na check is what aborts rather than a geometry check.
   x <- as.numeric(seq_len(60))
   x[10] <- NA


### PR DESCRIPTION
Step 1 of the [three-tier interface design](https://github.com/animovement/aniprocess/issues/30#issuecomment-5295406469) for #30. Renames only — no new API, no behaviour change.

A generic wrapper cannot forward arguments that disagree between the functions it dispatches to, so this has to land before the tiers can be built.

| current | → | why |
|---|---|---|
| `filter_sgolay(window_size)` | `window_width` | four other filters already use `window_width` |
| `find_peaks(window_size)` | `window_width` | same |
| `find_troughs(window_size)` | `window_width` | same |
| `filter_kalman(measurements)` | `x` | only vector-level functions whose first arg wasn't `x`; blocked `across()` |
| `filter_kalman_irregular(measurements)` | `x` | same |
| `filter_na_range(min, max)` | `min_value`, `max_value` | shadowed base functions; didn't match `min_gap`/`max_gap`/`min_obs` |

After this, the argument inventory is uniform:

```
window_width   filter_gaussian, filter_rollmean, filter_rollmedian,
               filter_sgolay, filter_triangular, find_peaks, find_troughs
first arg      data (6 aniframe-level), x (20 vector-level)  -- nothing else
```

`filter_ccma` keeps `window_width_ma`/`window_width_cc`, which are genuinely two distinct windows.

## No deprecation cycle

Checked every repo in the org — `aniread`, `animetric`, `aniframe`, `anicheck`, `anispace`, `anivis`, `movement-data` and the `animovement` meta-package. The only match was `anisegment`, and that's its own `classify_by_stability(window_size=)` parameter rather than a call into aniprocess (and not yet a package). The one hit in the `animovement` vignette is prose inside an HTML comment.

`R CMD check`: 0 errors, 0 warnings, 0 notes. 694 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)