### PR TITLE
Make the differencing filters round trip, and rename to on_deltas

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: aniprocess
 Type: Package
 Title: An R package for signal processing and filtering of movement data
-Version: 0.2.0.9006
+Version: 0.2.0.9007
 Authors@R: 
     person(
       "Mikkel", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,7 @@
   They do more than loop over columns. `variables` is a tidyselect expression defaulting to `variables_where`. Parameters the aniframe already knows are filled in: `sampling_rate` for the filters that need it, and the time column from `variables_when` for `"speed"` and `"kalman_irregular"`. Multivariate methods — `"ccma"`, and everything except `"range"` in `filter_na_across()` — are applied jointly rather than column by column. And `filter_na_across()` blanks `confidence` on the rows it masked, which the vector-level functions cannot do because `confidence` is not a coordinate.
 
   Per-row arguments such as `time` name a *column* at this level rather than taking a vector, since each group needs its own slice.
+* `filter_across()` names this argument `on_deltas` rather than `use_derivatives`: the values are differences, not derivatives — nothing is divided by a time step. `filter_aniframe()` keeps the old name, and both share one implementation.
 
 * New `filter_with()`, `filter_na_with()` and `replace_na_with()`: generic entry points that select a method by name rather than by choosing a function, which is the third step towards the unified interface in #30 (#30).
 
@@ -56,6 +57,8 @@
 * `keep_na` is validated: a non-logical, `NA`, or non-scalar value now aborts with a clear message rather than being silently coerced.
 
 ## Bug fixes
+
+* Differencing filters no longer lose the first sample or shift the series. `filter_aniframe(use_derivatives = TRUE)` differenced each column, filtered, then accumulated with `cumsum()` starting from zero — so the re-integrated series was offset by its own starting value and began with `NA`. With a filter that does nothing the round trip should be lossless; `c(10, 11, 13, 16, 20)` came back as `c(NA, 1, 3, 6, 10)`. It now re-integrates from the original starting value (#30).
 
 * `filter_na_speed()` now computes speed within each group of a grouped aniframe. It previously worked on the raw column vectors, so a step was formed between the last row of one track and the first row of the next. Where `time` restarts per track that step has a negative duration and yields a negative "speed", which inflated the `"auto"` threshold and caused genuine outliers to be **missed** — how badly depended on how far apart the tracks happened to be. The cross-track step never produced false positives, because per-row speed is the minimum of the backward and forward step and a track boundary is one-sided (#37).
 * `filter_na_speed()` no longer blanks rows belonging to groups shorter than two rows. Such a group has no step, so its speed is `NA`, and `dplyr::if_else()` propagates a missing condition (#37).

--- a/R/filter_across.R
+++ b/R/filter_across.R
@@ -31,10 +31,15 @@
 #' @param variables Columns to filter, as a tidyselect expression.
 #'   Defaults to the `variables_where` metadata field.
 #' @param ... Arguments passed to the underlying filter.
-#' @param use_derivatives If `TRUE`, difference each column, filter the
-#'   differences, and re-integrate. For trackball data, where the raw
-#'   measurements are per-frame displacements and the coordinates were
-#'   integrated from them, smoothing belongs on the displacements.
+#' @param on_deltas If `TRUE`, difference each column, filter the
+#'   differences, and re-integrate from the original starting value. For
+#'   trackball data, where the raw measurements are per-frame displacements
+#'   and the coordinates were integrated from them, smoothing belongs on
+#'   the displacements rather than on the integrated positions.
+#'
+#'   A `NA` among the filtered differences counts as no movement when
+#'   accumulating, and is restored as `NA` at its own position, so one
+#'   missing step does not blank the rest of the series.
 #'
 #' @return An aniframe of the same shape, with the selected columns
 #'   filtered.
@@ -68,7 +73,7 @@ filter_across <- function(
   ),
   variables = NULL,
   ...,
-  use_derivatives = FALSE
+  on_deltas = FALSE
 ) {
   method <- match.arg(method)
   ensure_aniframe_spatial(data)
@@ -109,7 +114,7 @@ filter_across <- function(
   }
 
   fn <- filter_method_fn(method)
-  if (isTRUE(use_derivatives)) {
+  if (isTRUE(on_deltas)) {
     fn <- derivative_wrapper(fn)
   }
 
@@ -167,7 +172,13 @@ filter_needs_sampling_rate <- function(method) {
 
 #' Wrap a filter so it acts on differences rather than on levels.
 #'
-#' Differences the column, filters the differences, then re-integrates.
+#' Differences the column, filters the differences, then re-integrates from
+#' the original starting value — so with a filter that does nothing, the
+#' round trip returns the input unchanged.
+#'
+#' A `NA` among the filtered differences is treated as no movement for the
+#' purpose of accumulation, and restored as `NA` at its own position, so one
+#' missing step does not blank the rest of the series.
 #'
 #' @param fn The filter to wrap.
 #'
@@ -180,6 +191,8 @@ derivative_wrapper <- function(fn) {
   function(col, ...) {
     d <- col - dplyr::lag(col)
     d <- fn(d, ...)
-    cumsum(dplyr::coalesce(d, 0)) + d * 0
+    # There is no step into the first sample; it *is* the starting point.
+    d[1] <- 0
+    col[1] + cumsum(dplyr::coalesce(d, 0)) + d * 0
   }
 }

--- a/R/filter_aniframe.R
+++ b/R/filter_aniframe.R
@@ -123,11 +123,9 @@ filter_aniframe <- function(
       dplyr::across(dplyr::all_of(variables_where), apply_filter)
     )
   } else {
-    integrate_filtered <- function(col) {
-      d <- col - dplyr::lag(col)
-      d <- apply_filter(d)
-      cumsum(dplyr::coalesce(d, 0)) + d * 0
-    }
+    # Shares derivative_wrapper() with filter_across(), so the two cannot
+    # drift apart.
+    integrate_filtered <- derivative_wrapper(apply_filter)
     dplyr::mutate(
       data,
       dplyr::across(dplyr::all_of(variables_where), integrate_filtered)

--- a/man/derivative_wrapper.Rd
+++ b/man/derivative_wrapper.Rd
@@ -13,6 +13,13 @@ derivative_wrapper(fn)
 A function with the same interface as \code{fn}.
 }
 \description{
-Differences the column, filters the differences, then re-integrates.
+Differences the column, filters the differences, then re-integrates from
+the original starting value — so with a filter that does nothing, the
+round trip returns the input unchanged.
+}
+\details{
+A \code{NA} among the filtered differences is treated as no movement for the
+purpose of accumulation, and restored as \code{NA} at its own position, so one
+missing step does not blank the rest of the series.
 }
 \keyword{internal}

--- a/man/filter_across.Rd
+++ b/man/filter_across.Rd
@@ -10,7 +10,7 @@ filter_across(
     "highpass", "lowpass_fft", "highpass_fft", "kalman", "kalman_irregular", "ccma"),
   variables = NULL,
   ...,
-  use_derivatives = FALSE
+  on_deltas = FALSE
 )
 }
 \arguments{
@@ -26,10 +26,15 @@ Defaults to the \code{variables_where} metadata field.}
 
 \item{...}{Arguments passed to the underlying filter.}
 
-\item{use_derivatives}{If \code{TRUE}, difference each column, filter the
-differences, and re-integrate. For trackball data, where the raw
-measurements are per-frame displacements and the coordinates were
-integrated from them, smoothing belongs on the displacements.}
+\item{on_deltas}{If \code{TRUE}, difference each column, filter the
+differences, and re-integrate from the original starting value. For
+trackball data, where the raw measurements are per-frame displacements
+and the coordinates were integrated from them, smoothing belongs on
+the displacements rather than on the integrated positions.
+
+A \code{NA} among the filtered differences counts as no movement when
+accumulating, and is restored as \code{NA} at its own position, so one
+missing step does not blank the rest of the series.}
 }
 \value{
 An aniframe of the same shape, with the selected columns

--- a/tests/testthat/test-filter_across.R
+++ b/tests/testthat/test-filter_across.R
@@ -137,13 +137,65 @@ test_that("filter_across returns an aniframe and preserves grouping", {
   expect_equal(dplyr::group_vars(out), "individual")
 })
 
-test_that("filter_across use_derivatives matches filter_aniframe", {
+test_that("filter_across on_deltas matches filter_aniframe use_derivatives", {
   d <- grouped_fixture(np = 20)
 
   expect_equal(
-    filter_across(d, "rollmean", window_width = 3, use_derivatives = TRUE)$x,
+    filter_across(d, "rollmean", window_width = 3, on_deltas = TRUE)$x,
     filter_aniframe(d, "rollmean", window_width = 3, use_derivatives = TRUE)$x
   )
+})
+
+test_that("on_deltas round trips when the filter does nothing", {
+  # window_width = 1 makes rollmean the identity, so differencing and
+  # re-integrating must return the input unchanged.
+  d <- aniframe::aniframe(
+    time = 1:5,
+    x = c(10, 11, 13, 16, 20),
+    y = c(-3, -3, -1, 2, 6),
+    variables_what = character(0)
+  )
+  out <- filter_across(d, "rollmean", window_width = 1, on_deltas = TRUE)
+
+  expect_equal(out$x, d$x)
+  expect_equal(out$y, d$y)
+})
+
+test_that("on_deltas keeps the original starting value", {
+  d <- aniframe::aniframe(
+    time = 1:20,
+    x = 100 + cumsum(c(0, rnorm(19))),
+    y = rep(0, 20),
+    variables_what = character(0)
+  )
+  out <- filter_across(d, "rollmean", window_width = 3, on_deltas = TRUE)
+
+  expect_equal(out$x[1], d$x[1])
+  expect_false(is.na(out$x[1]))
+})
+
+test_that("on_deltas restores NA at a missing step without blanking the rest", {
+  d <- aniframe::aniframe(
+    time = 1:6,
+    x = c(10, 11, NA, 16, 20, 25),
+    y = rep(0, 6),
+    variables_what = character(0)
+  )
+  out <- filter_across(d, "rollmean", window_width = 1, on_deltas = TRUE)
+
+  # The steps into and out of the gap are unknown, so those positions are NA
+  expect_true(any(is.na(out$x)))
+  # but the series continues afterwards
+  expect_false(is.na(out$x[6]))
+})
+
+test_that("on_deltas respects grouping", {
+  d <- grouped_fixture(np = 10)
+  out <- filter_across(d, "rollmean", window_width = 1, on_deltas = TRUE)
+
+  # Each track re-integrates from its own starting value
+  expect_equal(out$x[1], d$x[1])
+  expect_equal(out$x[11], d$x[11])
 })
 
 test_that("filter_across errors on a missing selected column", {


### PR DESCRIPTION
**Stacked on #45** — base is `refactor/across-verbs`. Closes the `use_derivatives` item from the [step-5 list](https://github.com/animovement/aniprocess/issues/30#issuecomment-5295406469).

## The bug

`use_derivatives = TRUE` differenced each column, filtered the differences, then accumulated with `cumsum()` **starting from zero**. So the re-integrated series was offset from the input by its own starting value, and the first sample came back as `NA`.

With `window_width = 1` the filter is the identity, so the round trip should be lossless:

```
                   before          after
input           : 10 11 13 16 20 | 10 11 13 16 20
use_derivatives : NA  1  3  6 10 | 10 11 13 16 20
```

Fix: re-integrate from `col[1]`, and treat the first sample as the starting point rather than as a step into itself.

A `NA` among the filtered differences still counts as no movement when accumulating and is restored at its own position, so one missing step doesn't blank the rest of the series — that behaviour is preserved and now documented.

## Shared implementation

`filter_aniframe()` had its own inline copy of the reconstruction. It now shares `derivative_wrapper()` with `filter_across()`, so the two can't drift apart — and both are fixed by the one change.

## Rename

`filter_across()` names the argument **`on_deltas`**. These are differences, not derivatives — nothing is divided by a time step. Being brand new, `filter_across()` can take the better name with no breakage; `filter_aniframe()` keeps `use_derivatives` and is deprecated in the next PR anyway.

`R CMD check`: 0 errors, 0 warnings, 0 notes. **877 tests, 100.00% coverage.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)