### PR TITLE
Use development version 0.3.0.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: aniprocess
 Type: Package
 Title: An R package for signal processing and filtering of movement data
-Version: 0.3.0
+Version: 0.3.0.9000
 Authors@R: 
     person(
       "Mikkel", 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# aniprocess (development version)
+
 # aniprocess 0.3.0
 
 ## Breaking changes


### PR DESCRIPTION
Post-release bookkeeping, following the tag and release of [v0.3.0](https://github.com/animovement/aniprocess/releases/tag/v0.3.0).

* `DESCRIPTION` → `0.3.0.9000`
* `NEWS.md` gains a `# aniprocess (development version)` heading above the 0.3.0 section

Without this, r-universe rebuilds every commit but still advertises `0.3.0`, so anyone already on `0.3.0` never receives them — `install.packages()` compares versions and sees no work to do. It also means two people reporting a bug against "0.3.0" can be running different code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)