### PR TITLE
Release aniprocess 0.4.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ message: 'To cite package "aniprocess" in publications use:'
 type: software
 license: MIT
 title: 'aniprocess: An R package for signal processing and filtering of movement data.'
-version: 0.3.0
-date-released: 2026-08-14
+version: 0.4.0
+date-released: 2026-08-18
 identifiers:
   - type: doi
     value: 10.5281/zenodo.17357778

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: aniprocess
 Type: Package
 Title: An R package for signal processing and filtering of movement data
-Version: 0.3.0.9001
+Version: 0.4.0
 Authors@R: 
     person(
       "Mikkel", 
@@ -17,7 +17,7 @@ BugReports: https://github.com/animovement/aniprocess/issues
 Encoding: UTF-8
 LazyData: true
 Imports:
-    aniframe (>= 0.6.0.9005),
+    aniframe (>= 0.7.0),
     cli,
     data.table (>= 1.18.0),
     dplyr (>= 1.1.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,22 +1,14 @@
-# aniprocess (development version)
+# aniprocess 0.4.0 (2026-08-18)
 
 ## New features
 
-* `filter_na_across()` gains `on_deltas`, matching `filter_across()`: it differences each column, masks the differences, and re-integrates from the original starting value (#54). Where the coordinates are cumulative — trackball data, whose raw readings are per-window displacements — masking a position blanks the sample you flagged but leaves the spurious jump baked into every position after it; masking the displacement removes the bad step, and everything downstream shifts back into place.
+* `filter_na_across()` gains `on_deltas`, matching `filter_across()`: it differences each column, masks the differences, and re-integrates from the original starting value (#54). Where coordinates are cumulative — trackball data, whose readings are per-window displacements — masking a position blanks the flagged sample but leaves the spurious jump in every position after it; masking the displacement removes the jump itself.
 
-  ```r
-  filter_na_across(trackball, "range", min_value = -10, max_value = 10, on_deltas = TRUE)
-  ```
-
-  A masked step counts as no movement and is restored as `NA` at its own sample alone, so the `NA` does not propagate forward. Only `"range"` accepts `on_deltas`; `"speed"` and `"excursion"` already judge between-sample change, and `"roi"` and `"confidence"` are not about displacement at all, so each errors with the reason rather than quietly computing something else.
+  Only `"range"` accepts it. `"speed"` and `"excursion"` already judge between-sample change, and `"roi"` and `"confidence"` are not about displacement, so each errors with the reason rather than computing something odd.
 
 ## Improvements
 
-* The aniframe-aware filters now use `aniframe::ensure_is_spatial()` instead of a local copy of the same check. `aniframe` 0.6.0.9005 exports the validator (animovement/aniframe#79), so `ensure_aniframe_spatial()` is gone and the metadata contract is enforced by the package that defines it.
-
-## Internal
-
-* Test fixtures that needed a frame whose metadata had drifted from its columns previously built it with `aniframe::set_metadata(variables_where = ...)`. That route is now refused (animovement/aniframe#82), and the fixtures produce the divergence the way it actually happens: `dplyr::select()` drops a declared column, or `dplyr::rename()` moves it out from under the declaration.
+* The aniframe-aware filters use `aniframe::ensure_is_spatial()` in place of a local copy, so the metadata contract is enforced by the package that defines it (animovement/aniframe#79). Requires aniframe 0.7.0.
 
 # aniprocess 0.3.0
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -11,4 +11,4 @@ bibentry(bibtype = "Misc",
          year = "2026",
          url = "http://animovement.dev/aniprocess/",
          abstract = "An R package for signal processing and filtering of movement data.",
-         version = "0.3.0")
+         version = "0.4.0")


### PR DESCRIPTION
Version, NEWS date, dependency pin and citation metadata — no code changes.

## Why 0.4.0

`filter_na_across()` gained `on_deltas`, which is a new user-facing feature.

## Dependency pin

`aniframe (>= 0.6.0.9005)` → `(>= 0.7.0)`. The development pin should not ship in a release, and `ensure_is_spatial()` — which the filters now use — is in 0.7.0, released today.

## NEWS

Condensed to highlights: the `on_deltas` entry keeps what it does and which criteria accept it, and the internal note about test fixtures is dropped, since that detail lives in the PR.

## Checks

913 tests passing, covr **100%**, `air format .` clean, `R CMD check` clean — run against aniframe 0.7.0 from r-universe, not a local build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)