### PR TITLE
Announce releases on Zulip

### DIFF
--- a/.github/workflows/release-to-zulip.yml
+++ b/.github/workflows/release-to-zulip.yml
@@ -3,11 +3,50 @@ name: Post Release Notes on Zulip
 on:
   release:
     types: [published]
+  # Lets an already-published release be announced by hand, and lets a failed
+  # announcement be re-sent. Deliberately not done by re-publishing a release:
+  # some repositories also have Zenodo listening for `release` events, which
+  # would mint a duplicate DOI version.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to announce. Leave empty for the latest release."
+        required: false
+        type: string
 
 jobs:
   notify-zulip:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
+      - name: Look up the release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "release" ]; then
+            tag="$EVENT_TAG"
+          elif [ -n "$INPUT_TAG" ]; then
+            tag="$INPUT_TAG"
+          else
+            tag=$(gh release view --json tagName --jq '.tagName')
+          fi
+          gh release view "$tag" --json tagName,name,url,body > release.json
+          {
+            echo "tag=$(jq -r '.tagName' release.json)"
+            echo "name=$(jq -r '.name' release.json)"
+            echo "url=$(jq -r '.url' release.json)"
+            echo "body<<ZULIP_RELEASE_BODY"
+            jq -r '.body' release.json
+            echo "ZULIP_RELEASE_BODY"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Send release notification to Zulip
         uses: zulip/github-actions-zulip/send-message@v1
         with:
@@ -22,7 +61,7 @@ jobs:
           # suppressed when it only repeats the tag or "<package> <tag>" --
           # both naming styles are in use across the ecosystem.
           content: |
-            # [${{ github.event.repository.name }} ${{ github.event.release.tag_name }}](${{ github.event.release.html_url }})
-            ${{ (github.event.release.name != '' && github.event.release.name != github.event.release.tag_name && github.event.release.name != format('{0} {1}', github.event.repository.name, github.event.release.tag_name)) && format('**{0}**', github.event.release.name) || '' }}
+            # [${{ github.event.repository.name }} ${{ steps.release.outputs.tag }}](${{ steps.release.outputs.url }})
+            ${{ (steps.release.outputs.name != '' && steps.release.outputs.name != steps.release.outputs.tag && steps.release.outputs.name != format('{0} {1}', github.event.repository.name, steps.release.outputs.tag)) && format('**{0}**', steps.release.outputs.name) || '' }}
 
-            ${{ github.event.release.body }}
+            ${{ steps.release.outputs.body }}

--- a/.github/workflows/release-to-zulip.yml
+++ b/.github/workflows/release-to-zulip.yml
@@ -1,0 +1,28 @@
+name: Post Release Notes on Zulip
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify-zulip:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send release notification to Zulip
+        uses: zulip/github-actions-zulip/send-message@v1
+        with:
+          api-key: ${{ secrets.ZULIP_API_KEY }}
+          email: "releases-bot@animovement.zulipchat.com"
+          organization-url: "https://animovement.zulipchat.com"
+          to: "announcements"
+          type: "stream"
+          topic: "releases"
+          # The heading is the package and its tag, so a shared `releases`
+          # topic stays scannable. The release name follows as a subtitle,
+          # suppressed when it only repeats the tag or "<package> <tag>" --
+          # both naming styles are in use across the ecosystem.
+          content: |
+            # [${{ github.event.repository.name }} ${{ github.event.release.tag_name }}](${{ github.event.release.html_url }})
+            ${{ (github.event.release.name != '' && github.event.release.name != github.event.release.tag_name && github.event.release.name != format('{0} {1}', github.event.repository.name, github.event.release.tag_name)) && format('**{0}**', github.event.release.name) || '' }}
+
+            ${{ github.event.release.body }}

--- a/.github/workflows/release-to-zulip.yml
+++ b/.github/workflows/release-to-zulip.yml
@@ -25,6 +25,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+          PKG: ${{ github.event.repository.name }}
           EVENT_NAME: ${{ github.event_name }}
           EVENT_TAG: ${{ github.event.release.tag_name }}
           INPUT_TAG: ${{ inputs.tag }}
@@ -38,10 +39,23 @@ jobs:
             tag=$(gh release view --json tagName --jq '.tagName')
           fi
           gh release view "$tag" --json tagName,name,url,body > release.json
+
+          # Release names are written in several styles across the ecosystem:
+          # "v0.4.0", "anicheck 0.2.0", "animovement v0.7.4" and
+          # "v0.4.0 - one source of truth for dimensionality". The heading
+          # already carries the package and tag, so strip any leading package
+          # name, version and separator and keep only the descriptive part.
+          # Names that are nothing but a version leave an empty subtitle.
+          name=$(jq -r '.name // ""' release.json)
+          subtitle=$(printf '%s' "$name" \
+            | sed -E "s/^${PKG}[[:space:]]+//" \
+            | sed -E 's/^v?[0-9]+(\.[0-9]+)*([-.][A-Za-z0-9]+)*[[:space:]]*//' \
+            | sed -E 's/^[[:space:]]*[—–:-][[:space:]]*//')
+
           {
             echo "tag=$(jq -r '.tagName' release.json)"
-            echo "name=$(jq -r '.name' release.json)"
             echo "url=$(jq -r '.url' release.json)"
+            echo "subtitle=$subtitle"
             echo "body<<ZULIP_RELEASE_BODY"
             jq -r '.body' release.json
             echo "ZULIP_RELEASE_BODY"
@@ -56,12 +70,8 @@ jobs:
           to: "announcements"
           type: "stream"
           topic: "releases"
-          # The heading is the package and its tag, so a shared `releases`
-          # topic stays scannable. The release name follows as a subtitle,
-          # suppressed when it only repeats the tag or "<package> <tag>" --
-          # both naming styles are in use across the ecosystem.
           content: |
             # [${{ github.event.repository.name }} ${{ steps.release.outputs.tag }}](${{ steps.release.outputs.url }})
-            ${{ (steps.release.outputs.name != '' && steps.release.outputs.name != steps.release.outputs.tag && steps.release.outputs.name != format('{0} {1}', github.event.repository.name, steps.release.outputs.tag)) && format('**{0}**', steps.release.outputs.name) || '' }}
+            ${{ steps.release.outputs.subtitle != '' && format('**{0}**', steps.release.outputs.subtitle) || '' }}
 
             ${{ steps.release.outputs.body }}

--- a/.github/workflows/release-to-zulip.yml
+++ b/.github/workflows/release-to-zulip.yml
@@ -1,3 +1,6 @@
+# Announces releases on Zulip. The logic lives in animovement/.github so it is
+# maintained in one place; only the triggers have to be declared here, because
+# GitHub fires them against this repository.
 name: Post Release Notes on Zulip
 
 on:
@@ -16,62 +19,7 @@ on:
 
 jobs:
   notify-zulip:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Look up the release
-        id: release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          PKG: ${{ github.event.repository.name }}
-          EVENT_NAME: ${{ github.event_name }}
-          EVENT_TAG: ${{ github.event.release.tag_name }}
-          INPUT_TAG: ${{ inputs.tag }}
-        run: |
-          set -euo pipefail
-          if [ "$EVENT_NAME" = "release" ]; then
-            tag="$EVENT_TAG"
-          elif [ -n "$INPUT_TAG" ]; then
-            tag="$INPUT_TAG"
-          else
-            tag=$(gh release view --json tagName --jq '.tagName')
-          fi
-          gh release view "$tag" --json tagName,name,url,body > release.json
-
-          # Release names are written in several styles across the ecosystem:
-          # "v0.4.0", "anicheck 0.2.0", "animovement v0.7.4" and
-          # "v0.4.0 - one source of truth for dimensionality". The heading
-          # already carries the package and tag, so strip any leading package
-          # name, version and separator and keep only the descriptive part.
-          # Names that are nothing but a version leave an empty subtitle.
-          name=$(jq -r '.name // ""' release.json)
-          subtitle=$(printf '%s' "$name" \
-            | sed -E "s/^${PKG}[[:space:]]+//" \
-            | sed -E 's/^v?[0-9]+(\.[0-9]+)*([-.][A-Za-z0-9]+)*[[:space:]]*//' \
-            | sed -E 's/^[[:space:]]*[—–:-][[:space:]]*//')
-
-          {
-            echo "tag=$(jq -r '.tagName' release.json)"
-            echo "url=$(jq -r '.url' release.json)"
-            echo "subtitle=$subtitle"
-            echo "body<<ZULIP_RELEASE_BODY"
-            jq -r '.body' release.json
-            echo "ZULIP_RELEASE_BODY"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Send release notification to Zulip
-        uses: zulip/github-actions-zulip/send-message@v1
-        with:
-          api-key: ${{ secrets.ZULIP_API_KEY }}
-          email: "releases-bot@animovement.zulipchat.com"
-          organization-url: "https://animovement.zulipchat.com"
-          to: "announcements"
-          type: "stream"
-          topic: "releases"
-          content: |
-            # [${{ github.event.repository.name }} ${{ steps.release.outputs.tag }}](${{ steps.release.outputs.url }})
-            ${{ steps.release.outputs.subtitle != '' && format('**{0}**', steps.release.outputs.subtitle) || '' }}
-
-            ${{ steps.release.outputs.body }}
+    uses: animovement/.github/.github/workflows/release-to-zulip.yml@main
+    with:
+      tag: ${{ inputs.tag }}
+    secrets: inherit


### PR DESCRIPTION
Announces releases on **announcements > releases** in Zulip.

The logic lives in [`animovement/.github`](https://github.com/animovement/.github/pull/2) as a reusable workflow, so this repository only declares the triggers — GitHub fires those against this repository, so they cannot be centralised, but nothing else has to live here. About 20 lines instead of 90, and the behaviour changes in one place for all eight packages.

**Merge [animovement/.github#2](https://github.com/animovement/.github/pull/2) first.** This stub fails until the reusable workflow is on `main` there.

## What it posts

```
# aniframe v0.7.0          <- links to the release
<bold subtitle, when the release name has one>

<release notes, with issue references linked>
```

The heading is the package and its tag, so a shared `releases` topic stays scannable. The subtitle is derived by stripping any leading package name, version and separator from the release name — `v0.7.0`, `anicheck 0.2.0` and `animovement v0.7.4` carry no description and produce nothing, while `v0.4.0 — one source of truth for dimensionality` yields the descriptive half.

Issue references are rewritten to explicit links: both `#82` and `animovement/aniframe#79`. Guarded so `##` headings, hex colours and URL fragments are untouched.

`workflow_dispatch` takes an optional `tag`, empty meaning the latest release, so releases published before this existed can still be announced and a failed send can be retried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
