### PR TITLE
Call the shared format-suggest workflow

### DIFF
--- a/.github/workflows/format-suggest.yaml
+++ b/.github/workflows/format-suggest.yaml
@@ -1,46 +1,21 @@
-# Workflow derived from https://github.com/posit-dev/setup-air/tree/main/examples
+# Suggests air formatting fixes on pull requests. The workflow lives in
+# animovement/.github so it is maintained in one place; only the trigger is
+# declared here.
+#
+# Using `pull_request_target` over `pull_request` for elevated `GITHUB_TOKEN`
+# privileges, otherwise we can't set `pull-requests: write` when the pull
+# request comes from a fork, which is our main use case (external contributors).
+# The shared workflow only reads and reformats the pull request's code, never
+# executes it, which is the case GitHub calls out as safe:
+# https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+name: format-suggest
 
 on:
-  # Using `pull_request_target` over `pull_request` for elevated `GITHUB_TOKEN`
-  # privileges, otherwise we can't set `pull-requests: write` when the pull
-  # request comes from a fork, which is our main use case (external contributors).
-  #
-  # `pull_request_target` runs in the context of the target branch (`main`, usually),
-  # rather than in the context of the pull request like `pull_request` does. Due
-  # to this, we must explicitly checkout `ref: ${{ github.event.pull_request.head.sha }}`.
-  # This is typically frowned upon by GitHub, as it exposes you to potentially running
-  # untrusted code in a context where you have elevated privileges, but they explicitly
-  # call out the use case of reformatting and committing back / commenting on the PR
-  # as a situation that should be safe (because we aren't actually running the untrusted
-  # code, we are just treating it as passive data).
-  # https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
   pull_request_target:
-
-name: format-suggest.yaml
 
 jobs:
   format-suggest:
-    name: format-suggest
-    runs-on: ubuntu-latest
-
+    uses: animovement/.github/.github/workflows/format-suggest.yml@main
     permissions:
-      # Required to push suggestion comments to the PR
       pull-requests: write
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Install
-        uses: posit-dev/setup-air@v1
-
-      - name: Format
-        run: air format .
-
-      - name: Suggest
-        uses: reviewdog/action-suggester@v1
-        with:
-          level: error
-          fail_level: error
-          tool_name: air
+    secrets: inherit


### PR DESCRIPTION
Replaces this repository's copy of `format-suggest` with a stub calling the shared workflow in [`animovement/.github`](https://github.com/animovement/.github/pull/4). Completes the centralisation started with the release announcement and the check workflows.

**Merge [animovement/.github#4](https://github.com/animovement/.github/pull/4) first.** This stub fails until the shared workflow is on `main` there.

`format-suggest` was byte-identical across all eight packages, so nothing is parameterised — the whole file moves. The `pull_request_target` trigger and the explanation for it stay here, since the trigger has to be declared in this repository anyway and that is where a reader looks for it.

This **changes the check name** from `format-suggest` to `format-suggest / format-suggest`, which matters only if it is added to required status checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
