### PR TITLE
docs: rewrite NEWS.md to the changelog standard

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,18 +1,18 @@
 # aniprocess 0.4.0 (2026-08-18)
 
-## New features
+## Added
 
 * `filter_na_across()` gains `on_deltas`, matching `filter_across()`: it differences each column, masks the differences, and re-integrates from the original starting value (#54). Where coordinates are cumulative — trackball data, whose readings are per-window displacements — masking a position blanks the flagged sample but leaves the spurious jump in every position after it; masking the displacement removes the jump itself.
 
   Only `"range"` accepts it. `"speed"` and `"excursion"` already judge between-sample change, and `"roi"` and `"confidence"` are not about displacement, so each errors with the reason rather than computing something odd.
 
-## Improvements
+## Changed
 
 * The aniframe-aware filters use `aniframe::ensure_is_spatial()` in place of a local copy, so the metadata contract is enforced by the package that defines it (animovement/aniframe#79). Requires aniframe 0.7.0.
 
 # aniprocess 0.3.0
 
-## Breaking changes
+## Changed
 
 * The interface is now split into three tiers (#30). The individual functions work on a vector or a frame of coordinate columns, `*_with()` selects a method by name, and `*_across()` applies one to a whole aniframe.
 
@@ -29,34 +29,31 @@
 * Argument names are consistent across the package: `window_width` replaces `window_size` in `filter_sgolay()`, `find_peaks()` and `find_troughs()`; `x` replaces `measurements` in the Kalman filters; `min_value`/`max_value` replace `min`/`max` in `filter_na_range()`.
 * `filter_na_confidence()` no longer masks rows whose confidence is `NA`, and warns instead — a missing score means *not assessed*, not *poor*.
 * `filter_na_across(method = "speed")` estimates an `"auto"` threshold per group. Pass `threshold = "pooled"` for a single estimate across all groups, which is steadier when tracks are short.
+* `filter_ccma()` and `filter_na_excursion()` no longer scale quadratically in the number of groups. At 3,000 groups they are roughly 8× and 3.5× faster (#37).
 
-## New features
+## Added
 
 * New `filter_one_euro()`: the One Euro filter (Casiez, Roussel & Vogel, 2012), an adaptive low-pass whose cutoff rises with the speed of the signal — smooth when the animal is still, responsive when it moves (#35).
 * `*_across()` uses what the aniframe already knows: `sampling_rate` and the time column come from its metadata. `variables` selects columns with tidyselect, defaulting to `variables_where`.
 * `keep_na` is available on every filter, and validated.
 
-## Bug fixes
+## Fixed
 
 * `filter_na_speed()` computes speed within each group, so a step is never formed between one track and the next. Where `time` restarts per track that step inflated the `"auto"` threshold and caused genuine outliers to be missed (#37).
 * Differencing filters (`on_deltas`, formerly `use_derivatives`) re-integrate from the original starting value; they previously dropped the first sample and shifted the whole series (#30).
 * `filter_na_speed()` no longer blanks groups too short to contain a step (#37).
 * The `data.table (>= 1.18.0)` requirement is enforced when the package loads, not only when it is installed (#33).
 
-## Performance
-
-* `filter_ccma()` and `filter_na_excursion()` no longer scale quadratically in the number of groups. At 3,000 groups they are roughly 8× and 3.5× faster (#37).
-
 # aniprocess 0.2.0
 
-## New features
+## Added
 
 * New `filter_ccma()`: Curvature-Corrected Moving Average for 2D/3D Cartesian trajectories (Steinecker & Wuensche, 2023). Hanning and uniform kernels; padding boundary mode (#11).
 * New `filter_na_excursion()`: flags multi-frame tracking excursions using the criterion from Todd, Kain & de Bivort (2017) — a jump that eventually returns counts as an outlier; a sustained shift does not (#13).
 * New `filter_gaussian()`: Gaussian kernel smoother with NA-aware weight renormalisation (#1).
 * New `filter_triangular()`: triangular smoother as two passes of `filter_rollmean()` (#1).
 
-## Bug fixes
+## Fixed
 
 * `filter_lowpass_fft()` / `filter_highpass_fft()`: fixed an asymmetric frequency-domain mask that halved the passband amplitude. Lowpass + highpass at the same cutoff now reconstruct the input exactly.
 * `filter_na_speed()` now flags single-frame outliers correctly (the outlier itself is blanked, not its neighbours), and a single NA in the input no longer contaminates adjacent rows (#14).
@@ -66,26 +63,38 @@
 * `filter_kalman()` documentation: corrected the default `base_Q` formula.
 * `replace_na_stine()` and the inline installer in `filter_bandwidth.R` now point at the current r-universe (#17).
 
-## Breaking changes
+## Changed
 
 * `filter_sgolay()`: dropped `preserve_edges`.
 * `filter_rollmean()` / `filter_rollmedian()`: dropped `...`, gained an explicit `align` argument (#7).
-
-## Dependencies
-
 * `data.table (>= 1.18.0)` promoted from `Suggests` to `Imports` (now backs the rolling filters and the LOCF interpolation step).
 * Removed `roll`, `collapse`, and `animetric`.
 
-## Internal / housekeeping
-
-* New helpers `ensure_replace_na_args()` and `ensure_aniframe_spatial()` replace duplicated input validation across the `replace_na_*()` and `filter_na_*()` families.
-* `check_*()` helpers for optional packages consolidated, so the canonical r-universe URL lives in a single place.
-* Three dead files removed; future work tracked in #29 (`filter_by_pose`) and #30 (an across-style API).
-* Package now at 100% line coverage; `covr` added to `Suggests`.
-
 # aniprocess 0.1.2
 
-* Added a `NEWS.md` file to track changes to the package.
-* Update to work with tidy movement logic.
-* Use `differentiate` from *animetric* for `filter_na_speed`.
-* `filter_na_roi` now works with 3D ROIs.
+## Added
+
+* A `NEWS.md` file, to track changes to the package.
+
+## Changed
+
+* Updated to the tidy movement data model of aniframe 0.4.0.
+* `filter_na_speed()` uses `differentiate()` from animetric rather than its own derivative.
+* `filter_na_roi()` accepts 3D regions of interest.
+
+# aniprocess 0.1.1
+
+The package takes its present shape: masking, gap filling and smoothing.
+
+## Added
+
+* NA masking: `filter_na_confidence()`, `filter_na_speed()`, `filter_na_range()` and `filter_na_roi()`.
+* Gap filling: `replace_na_linear()`, `replace_na_spline()`, `replace_na_stine()`, `replace_na_locf()`, `replace_na_value()` and the generic `replace_na()`.
+* Smoothing and filtering: `filter_sgolay()`, `filter_rollmean()`, `filter_rollmedian()`, `filter_lowpass()`, `filter_highpass()`, their `_fft()` counterparts, `filter_kalman()` and `filter_kalman_irregular()`.
+* Peak detection: `find_peaks()` and `find_troughs()`.
+* `filter_aniframe()`, the frame-level entry point.
+
+# aniprocess 0.1.0
+
+Package skeleton. No filters yet.
+


### PR DESCRIPTION
## Description

### What kind of change is this?

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Documentation
- [ ] Maintenance (CI, dependencies, refactoring)
- [ ] Other

### Why is it needed?

Applies the changelog standard from animovement/.github#22.

### What does it do?

Sections become Keep a Changelog's six. Two of the mappings here are the standard's own worked examples:

**`Performance` → `Changed`.** 0.3.0's bullet reads *"`filter_ccma()` and `filter_na_excursion()` no longer scale quadratically in the number of groups. At 3,000 groups they are roughly 8× and 3.5× faster (#37)."* That is precisely the case Keep a Changelog names — *"Rewrote JSON parser; 3x faster on large files' fits better under `Changed` than `Performance`"* — so it moves rather than keeping a section of its own.

**`Internal / housekeeping` → dropped.** Its four bullets were extracted validation helpers, consolidated `check_*()` functions, three deleted files, and a coverage figure. None is observable from outside the package, which is the test the standard sets.

`Dependencies` and `Improvements` fold into `Changed`; duplicate sections created by the mapping are merged.

**0.1.0 and 0.1.1 had no entry.** 0.1.1 is where the package took its present shape — masking, gap filling, smoothing and peak detection arrived together, twenty-two exports in one version — and the file said nothing about it.

| | before | after |
|---|---|---|
| version sections | 4 | 6 |
| bullets | 41 | 42 |

Two versions added, four housekeeping bullets removed.

### On references

Fourteen, all resolving. `animovement/aniframe#79` is a cross-repo reference — my checker looked for it in this repository and flagged it; it is [aniframe#79](https://github.com/animovement/aniframe/issues/79), closed, and correct as written.

### Dates

Given only for versions with a GitHub release. Untagged version bumps that r-universe built have no release date to cite, and taking the commit date would assert more than is known.

## References

Applies animovement/.github#22.

## How has this PR been tested?

`NEWS.md` only; no code. Headings match the form pkgdown's `build_news()` requires, and every issue reference was checked against the repository.

**GitHub Actions is in a major outage** ([incident from 15:11 UTC](https://www.githubstatus.com)), so checks here will not run or will fail at startup. They need re-running once it recovers — a `startup_failure` on this branch is the outage, not the change.

## Is this a breaking change?

No — a changelog. Released sections are edited for shape, not content.

## Does this PR require a documentation update?

This is the documentation update.

## Checklist

- [ ] Tests pass locally (`devtools::test()`) — N/A, no R code touched
- [ ] Tests have been added covering new functionality — N/A
- [ ] Documentation regenerated if roxygen comments changed — N/A
- [x] Code is formatted — markdown only
- [x] A `NEWS.md` bullet added under `# (development version)` — this PR is the `NEWS.md` change
- [x] I have read and understood every change I am submitting, and tested it myself

🤖 Generated with [Claude Code](https://claude.com/claude-code)
