### PR TITLE
chore: adopt anicore

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ BugReports: https://github.com/animovement/aniprocess/issues
 Encoding: UTF-8
 LazyData: true
 Imports:
-    aniframe (>= 0.7.0),
+    anicore (>= 0.7.0),
     cli,
     data.table (>= 1.18.0),
     dplyr (>= 1.1.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 ## Improvements
 
-* The aniframe-aware filters use `aniframe::ensure_is_spatial()` in place of a local copy, so the metadata contract is enforced by the package that defines it (animovement/aniframe#79). Requires aniframe 0.7.0.
+* The aniframe-aware filters use `anicore::ensure_is_spatial()` in place of a local copy, so the metadata contract is enforced by the package that defines it (animovement/aniframe#79). Requires aniframe 0.7.0.
 
 # aniprocess 0.3.0
 

--- a/R/across_helpers.R
+++ b/R/across_helpers.R
@@ -11,7 +11,7 @@
 #' @keywords internal
 resolve_variables <- function(data, variables, call = rlang::caller_env()) {
   if (rlang::quo_is_null(variables)) {
-    return(aniframe::get_metadata(data, "variables_where"))
+    return(anicore::get_metadata(data, "variables_where"))
   }
 
   selected <- names(tidyselect::eval_select(variables, data, error_call = call))
@@ -42,7 +42,7 @@ resolve_variables <- function(data, variables, call = rlang::caller_env()) {
 #' @return The metadata value.
 #' @keywords internal
 metadata_value <- function(data, field, what, call = rlang::caller_env()) {
-  value <- aniframe::get_metadata(data, field)
+  value <- anicore::get_metadata(data, field)
   if (length(value) == 0L || all(is.na(value))) {
     cli::cli_abort(
       c(

--- a/R/dispatch.R
+++ b/R/dispatch.R
@@ -29,7 +29,7 @@ dispatch_method <- function(
 ) {
   # An aniframe is a data frame, so without this it would be filtered
   # column-wise -- including `time` and any identity columns.
-  if (aniframe::is_aniframe(x)) {
+  if (anicore::is_aniframe(x)) {
     cli::cli_abort(
       c(
         "{.arg x} is an aniframe, but {.fn {generic}} works on a vector or a frame of coordinate columns.",

--- a/R/filter_across.R
+++ b/R/filter_across.R
@@ -77,7 +77,7 @@ filter_across <- function(
   on_deltas = FALSE
 ) {
   method <- match.arg(method)
-  aniframe::ensure_is_spatial(data)
+  anicore::ensure_is_spatial(data)
 
   variables <- resolve_variables(data, rlang::enquo(variables))
   args <- rlang::list2(...)
@@ -87,7 +87,7 @@ filter_across <- function(
     # The curvature math is Cartesian-specific, and only the aniframe knows
     # its coordinate system -- filter_ccma() sees bare columns.
     coord_system <- as.character(
-      aniframe::get_metadata(data, "coordinate_system")
+      anicore::get_metadata(data, "coordinate_system")
     )
     if (length(coord_system) > 0L && !startsWith(coord_system, "cartesian")) {
       cli::cli_abort(c(

--- a/R/filter_across.R
+++ b/R/filter_across.R
@@ -118,7 +118,7 @@ filter_across <- function(
   helpers <- list()
   if (method == "kalman_irregular") {
     helpers$times <- helper_column(args$times, "times", "filter_with") %||%
-      metadata_value(data, "variables_when", "which column holds time")[1]
+      anicore::get_index(data)
     args$times <- NULL
     if (!helpers$times %in% names(data)) {
       cli::cli_abort("Missing time column: {.val {helpers$times}}.")

--- a/R/filter_na_across.R
+++ b/R/filter_na_across.R
@@ -116,7 +116,7 @@ filter_na_across <- function(
   helpers <- list()
   if (method == "speed") {
     helpers$time <- helper_column(args$time, "time", "filter_na_with") %||%
-      metadata_value(data, "variables_when", "which column holds time")[1]
+      anicore::get_index(data)
     args$time <- NULL
   }
   if (method == "confidence") {

--- a/R/filter_na_across.R
+++ b/R/filter_na_across.R
@@ -89,7 +89,7 @@ filter_na_across <- function(
 ) {
   method <- match.arg(method)
   ensure_on_deltas_supported(method, on_deltas)
-  aniframe::ensure_is_spatial(data)
+  anicore::ensure_is_spatial(data)
 
   variables <- resolve_variables(data, rlang::enquo(variables))
   args <- rlang::list2(...)

--- a/R/replace_na_across.R
+++ b/R/replace_na_across.R
@@ -37,7 +37,7 @@ replace_na_across <- function(
   ...
 ) {
   method <- match.arg(method)
-  aniframe::ensure_is_spatial(data)
+  anicore::ensure_is_spatial(data)
 
   variables <- resolve_variables(data, rlang::enquo(variables))
   args <- c(list(method = method), rlang::list2(...))

--- a/renv.lock
+++ b/renv.lock
@@ -97,8 +97,8 @@
       "Authors@R": "person( \"Mikkel\",  \"Roald-Arbøl\",  role = c(\"aut\", \"cre\"),  email = \"animovement.84w1m@passmail.com\", comment = c(ORCID = \"0000-0002-9998-0058\") )",
       "Description": "An R package providing core data structures for movement data.",
       "License": "MIT + file LICENSE",
-      "URL": "http://animovement.dev/aniframe/, https://github.com/animovement/aniframe/",
-      "BugReports": "https://github.com/animovement/aniframe/issues",
+      "URL": "http://animovement.dev/anicore/, https://github.com/animovement/anicore/",
+      "BugReports": "https://github.com/animovement/anicore/issues",
       "Encoding": "UTF-8",
       "Depends": [
         "R (>= 4.1.0)"
@@ -124,7 +124,7 @@
       "Config/Needs/website": "animovement/animovementtemplate",
       "Config/roxygen2/version": "8.0.0",
       "Repository": "https://animovement.r-universe.dev",
-      "RemoteUrl": "https://github.com/animovement/aniframe",
+      "RemoteUrl": "https://github.com/animovement/anicore",
       "RemoteRef": "HEAD",
       "RemoteSha": "5b22cea9b4d079bebec9f0b45ee3b2d90726746f",
       "NeedsCompilation": "no",

--- a/tests/testthat/test-filter_across.R
+++ b/tests/testthat/test-filter_across.R
@@ -7,7 +7,7 @@
 # - use_derivatives round trip
 
 grouped_fixture <- function(np = 30, sampling_rate = 30) {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = rep(seq_len(np), 2),
     individual = rep(c("a", "b"), each = np),
     x = c(seq_len(np), seq_len(np) + 1000),
@@ -15,7 +15,7 @@ grouped_fixture <- function(np = 30, sampling_rate = 30) {
     variables_what = "individual"
   ) |>
     dplyr::group_by(individual)
-  aniframe::set_metadata(d, sampling_rate = sampling_rate)
+  anicore::set_metadata(d, sampling_rate = sampling_rate)
 }
 
 test_that("filter_across applies each method column by column", {
@@ -49,13 +49,13 @@ test_that("filter_across takes sampling_rate from metadata", {
 })
 
 test_that("filter_across errors when sampling_rate is unavailable", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:20,
     x = as.numeric(1:20),
     y = as.numeric(1:20),
     variables_what = character(0)
   )
-  d <- aniframe::set_metadata(d, sampling_rate = NA)
+  d <- anicore::set_metadata(d, sampling_rate = NA)
 
   expect_error(
     filter_across(d, "lowpass", cutoff_freq = 5),
@@ -64,7 +64,7 @@ test_that("filter_across errors when sampling_rate is unavailable", {
 })
 
 test_that("filter_across takes the time column from variables_when", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = c(0, 0.1, 0.3, 0.35, 0.5, 0.8),
     x = c(1, 1.1, 2, 0.9, 1.2, 0.8),
     y = c(1, 1.1, 2, 0.9, 1.2, 0.8),
@@ -104,7 +104,7 @@ test_that("filter_across rejects a selection with no columns or non-numeric ones
 test_that("filter_across applies ccma jointly", {
   np <- 60
   t <- seq(0, 2 * pi, length.out = np)
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = seq_len(np),
     x = cos(t),
     y = sin(t),
@@ -148,7 +148,7 @@ test_that("filter_across returns an aniframe and preserves grouping", {
 test_that("on_deltas round trips when the filter does nothing", {
   # window_width = 1 makes rollmean the identity, so differencing and
   # re-integrating must return the input unchanged.
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:5,
     x = c(10, 11, 13, 16, 20),
     y = c(-3, -3, -1, 2, 6),
@@ -161,7 +161,7 @@ test_that("on_deltas round trips when the filter does nothing", {
 })
 
 test_that("on_deltas keeps the original starting value", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:20,
     x = 100 + cumsum(c(0, rnorm(19))),
     y = rep(0, 20),
@@ -174,7 +174,7 @@ test_that("on_deltas keeps the original starting value", {
 })
 
 test_that("on_deltas restores NA at a missing step without blanking the rest", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:6,
     x = c(10, 11, NA, 16, 20, 25),
     y = rep(0, 6),
@@ -198,7 +198,7 @@ test_that("on_deltas respects grouping", {
 })
 
 test_that("filter_across errors on a missing selected column", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:5,
     x = as.numeric(1:5),
     y = as.numeric(1:5),
@@ -212,13 +212,13 @@ test_that("filter_across errors on a missing selected column", {
 
 test_that("filter_across dispatches every method", {
   np <- 40
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = seq_len(np),
     x = sin(2 * pi * 2 * seq(0, 1, length.out = np)),
     y = cos(2 * pi * 2 * seq(0, 1, length.out = np)),
     variables_what = character(0)
   )
-  d <- aniframe::set_metadata(d, sampling_rate = 40)
+  d <- anicore::set_metadata(d, sampling_rate = 40)
 
   simple <- c("gaussian", "rollmean", "rollmedian", "triangular", "kalman")
   freq <- c("lowpass", "highpass", "lowpass_fft", "highpass_fft")
@@ -235,7 +235,7 @@ test_that("filter_across dispatches every method", {
 })
 
 test_that("filter_across errors when variables_when names a missing column", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:6,
     x = as.numeric(1:6),
     y = as.numeric(1:6),
@@ -250,7 +250,7 @@ test_that("filter_across errors when variables_when names a missing column", {
 # --- aniframe shapes: identity columns, metadata edge cases, 3D ------------
 
 test_that("filter_across works with the default example aniframe", {
-  d <- aniframe::example_aniframe()
+  d <- anicore::example_aniframe()
   expect_no_error(filter_across(d))
   expect_s3_class(filter_across(d), "aniframe")
 })
@@ -260,7 +260,7 @@ test_that("filter_across inherits the grouping aniframe derives from variables_w
   # never has to read that metadata itself -- it just honours the grouping
   # that is already on the frame.
   n <- 10
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     track = rep(c("a", "b"), each = n / 2),
     time = rep(seq_len(n / 2), 2),
     x = c(seq_len(n / 2), seq_len(n / 2) + 1000),
@@ -288,12 +288,12 @@ test_that("filter_across inherits the grouping aniframe derives from variables_w
 test_that("filter_across works when variables_what names a missing column", {
   # aniframe can carry a default variables_what (e.g. "keypoint") even when
   # the column is absent. Nothing reads it, so this must simply work.
-  d <- aniframe::aniframe(time = 1:20, x = rnorm(20), y = rnorm(20))
+  d <- anicore::aniframe(time = 1:20, x = rnorm(20), y = rnorm(20))
   expect_no_error(filter_across(d, "rollmean", window_width = 3))
 })
 
 test_that("filter_across filters z when it is a spatial variable", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:20,
     x = rnorm(20),
     y = rnorm(20),

--- a/tests/testthat/test-filter_ccma.R
+++ b/tests/testthat/test-filter_ccma.R
@@ -11,7 +11,7 @@
 test_that("filter_ccma reduces radius shrinkage on a noiseless circle", {
   n <- 100
   t <- seq(0, 2 * pi, length.out = n)
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = seq_len(n),
     x = cos(t),
     y = sin(t),
@@ -40,7 +40,7 @@ test_that("filter_ccma reduces radius shrinkage on a noiseless circle", {
 test_that("filter_ccma cc_mode = FALSE returns only the moving-average result", {
   n <- 50
   t <- seq(0, 2 * pi, length.out = n)
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = seq_len(n),
     x = cos(t),
     y = sin(t),
@@ -53,7 +53,7 @@ test_that("filter_ccma cc_mode = FALSE returns only the moving-average result", 
 
 test_that("filter_ccma preserves input length and aniframe class", {
   n <- 60
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = seq_len(n),
     x = rnorm(n),
     y = rnorm(n),
@@ -67,7 +67,7 @@ test_that("filter_ccma preserves input length and aniframe class", {
 test_that("filter_ccma works in 3D", {
   n <- 60
   t <- seq(0, 4 * pi, length.out = n)
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = seq_len(n),
     x = cos(t),
     y = sin(t),
@@ -87,7 +87,7 @@ test_that("filter_ccma preserves NAs by default and fills with keep_na = FALSE",
   x <- cos(t)
   y <- sin(t)
   x[c(10, 30)] <- NA
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = seq_len(n),
     x = x,
     y = y,
@@ -105,7 +105,7 @@ test_that("filter_ccma preserves NAs by default and fills with keep_na = FALSE",
 })
 
 test_that("filter_ccma errors when na_action = 'error' and NAs are present", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:10,
     x = c(rnorm(9), NA),
     y = rnorm(10),
@@ -118,7 +118,7 @@ test_that("filter_ccma operates per group", {
   # Two tracks, second one has different curvature
   n <- 60
   t <- seq(0, 2 * pi, length.out = n)
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     track = rep(c("a", "b"), each = n),
     time = rep(seq_len(n), 2),
     x = c(cos(t), 2 * cos(t)),
@@ -137,7 +137,7 @@ test_that("filter_ccma operates per group", {
 })
 
 test_that("filter_ccma rejects 1-D variables_where", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:10,
     x = rnorm(10),
     variables_where = "x",
@@ -147,7 +147,7 @@ test_that("filter_ccma rejects 1-D variables_where", {
 })
 
 test_that("filter_ccma validates window widths", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:20,
     x = rnorm(20),
     y = rnorm(20),
@@ -163,7 +163,7 @@ test_that("filter_ccma rounds even window widths up to odd", {
   # next odd width up (i.e. the rounding actually happens).
   n <- 60
   t <- seq(0, 2 * pi, length.out = n)
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = seq_len(n),
     x = cos(t),
     y = sin(t),
@@ -182,7 +182,7 @@ test_that("filter_ccma rounds even window widths up to odd", {
 test_that("filter_ccma uniform kernel runs and returns expected length", {
   n <- 60
   t <- seq(0, 2 * pi, length.out = n)
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = seq_len(n),
     x = cos(t),
     y = sin(t),
@@ -211,7 +211,7 @@ test_that("filter_ccma accepts a coordinate frame and returns one", {
 
 test_that("filter_ccma coordinate-frame form matches the aniframe form", {
   t <- seq(0, 2 * pi, length.out = 60)
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = seq_len(60),
     x = cos(t),
     y = sin(t),
@@ -232,7 +232,7 @@ test_that("filter_ccma rejects a coordinate frame with a non-numeric column", {
 })
 
 test_that("filter_ccma errors when a variables_where column is missing", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:10,
     x = rnorm(10),
     y = rnorm(10),
@@ -243,7 +243,7 @@ test_that("filter_ccma errors when a variables_where column is missing", {
 })
 
 test_that("filter_ccma errors when a spatial column is non-numeric", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:10,
     x = rnorm(10),
     y = rnorm(10),
@@ -257,7 +257,7 @@ test_that("filter_ccma returns the input when NAs cannot be filled", {
   # An all-NA column triggers the can't-interpolate fallback.
   n <- 30
   t <- seq(0, 2 * pi, length.out = n)
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = seq_len(n),
     x = rep(NA_real_, n),
     y = sin(t),
@@ -268,7 +268,7 @@ test_that("filter_ccma returns the input when NAs cannot be filled", {
 })
 
 test_that("filter_ccma passes through trajectories shorter than 3 points", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:2,
     x = c(0, 1),
     y = c(0, 1),
@@ -285,7 +285,7 @@ test_that("filter_ccma handles straight-line trajectories (zero curvature)", {
   # under both MA and the (zero) curvature shift, and the interior of a
   # linear column is reproduced exactly.
   n <- 30
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = seq_len(n),
     x = seq_len(n) * 1.0,
     y = rep(0, n),
@@ -303,15 +303,15 @@ test_that("ccma_kernel rejects unknown kernel types", {
 })
 
 test_that("filter_ccma rejects non-Cartesian coordinate systems", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:10,
     x = rnorm(10),
     y = rnorm(10),
     variables_what = character(0)
   )
-  cs_levels <- levels(aniframe::get_metadata(d, "coordinate_system"))
+  cs_levels <- levels(anicore::get_metadata(d, "coordinate_system"))
   for (cs in c("polar", "cylindrical", "spherical", "unknown")) {
-    bad <- aniframe::set_metadata(
+    bad <- anicore::set_metadata(
       d,
       coordinate_system = factor(cs, levels = cs_levels)
     )
@@ -328,7 +328,7 @@ test_that("filter_ccma smooths each group independently", {
   a <- data.frame(time = seq_len(np), x = cos(t), y = sin(t))
   b <- data.frame(time = seq_len(np), x = cos(t) + 5000, y = sin(t) + 5000)
 
-  grouped <- aniframe::aniframe(
+  grouped <- anicore::aniframe(
     time = c(a$time, b$time),
     individual = rep(c("a", "b"), each = np),
     x = c(a$x, b$x),

--- a/tests/testthat/test-filter_na_across.R
+++ b/tests/testthat/test-filter_na_across.R
@@ -5,7 +5,7 @@
 # - Grouping is respected
 
 na_fixture <- function(np = 20) {
-  aniframe::aniframe(
+  anicore::aniframe(
     time = rep(seq_len(np), 2),
     individual = rep(c("a", "b"), each = np),
     x = c(c(0:8, 500, 10:(np - 1)), (0:(np - 1)) + 1000),
@@ -66,7 +66,7 @@ test_that("filter_na_across dispatches excursion and roi", {
   np <- 40
   x <- rnorm(np, sd = 2)
   x[10:12] <- x[10:12] + 40
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = seq_len(np),
     x = x,
     y = rnorm(np, sd = 2),
@@ -79,7 +79,7 @@ test_that("filter_na_across dispatches excursion and roi", {
   )
 
   coords <- data.frame(x = c(0, 10, 20), y = c(0, 10, 20))
-  d2 <- aniframe::aniframe(
+  d2 <- anicore::aniframe(
     time = 1:3,
     x = coords$x,
     y = coords$y,
@@ -94,7 +94,7 @@ test_that("filter_na_across dispatches excursion and roi", {
 })
 
 test_that("filter_na_across dispatches confidence and filters the column", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:4,
     x = c(1, 2, 3, 4),
     y = c(5, 6, 7, 8),
@@ -108,7 +108,7 @@ test_that("filter_na_across dispatches confidence and filters the column", {
 })
 
 test_that("filter_na_across errors when a required column is absent", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:4,
     x = c(1, 2, 3, 4),
     y = c(5, 6, 7, 8),
@@ -150,7 +150,7 @@ test_that("auto estimates a threshold per group, pooled estimates one overall", 
   # Ten rows per track is too few for mean + 3 sd to catch this outlier
   # within its own track, but enough when both tracks are pooled. The two
   # settings therefore disagree, which is what makes them distinguishable.
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = rep(1:10, 2),
     individual = rep(c("a", "b"), each = 10),
     x = c(c(0:3, 500, 5:9), (0:9) + 1e4),
@@ -182,7 +182,7 @@ test_that("a per-group auto threshold judges each track on its own noise", {
   xb <- cumsum(rnorm(np, sd = 0.1)) + 1e5
   xb[10] <- xb[10] + 3000
 
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = rep(seq_len(np), 2),
     individual = rep(c("a", "b"), each = np),
     x = c(xa, xb),
@@ -209,7 +209,7 @@ delta_fixture <- function(individuals = "a") {
   # each track starts somewhere different
   offset <- rep(100 * seq_len(ni), each = np)
 
-  aniframe::aniframe(
+  anicore::aniframe(
     time = rep(seq_len(np), ni),
     individual = rep(individuals, each = np),
     x = offset + rep(cumsum(steps), ni),

--- a/tests/testthat/test-filter_na_confidence.R
+++ b/tests/testthat/test-filter_na_confidence.R
@@ -19,7 +19,7 @@ test_that("filter_na_confidence filters with default threshold (2D)", {
     y = 6:10,
     confidence = c(0.5, 0.7, 0.4, 0.8, 0.9)
   ) |>
-    aniframe::as_aniframe()
+    anicore::as_aniframe()
 
   result <- filter_na_across(data, "confidence")
 
@@ -37,7 +37,7 @@ test_that("filter_na_confidence filters with default threshold (3D)", {
     z = 11:15,
     confidence = c(0.5, 0.7, 0.4, 0.8, 0.9)
   ) |>
-    aniframe::as_aniframe(variables_where = c("x", "y", "z"))
+    anicore::as_aniframe(variables_where = c("x", "y", "z"))
 
   result <- filter_na_across(data, "confidence")
 
@@ -56,7 +56,7 @@ test_that("filter_na_confidence filters with custom threshold", {
     z = 11:15,
     confidence = c(0.5, 0.7, 0.4, 0.8, 0.9)
   ) |>
-    aniframe::as_aniframe(variables_where = c("x", "y", "z"))
+    anicore::as_aniframe(variables_where = c("x", "y", "z"))
 
   result <- filter_na_across(data, "confidence", threshold = 0.75)
 
@@ -74,7 +74,7 @@ test_that("filter_na_confidence handles boundary values", {
     y = 5:8,
     confidence = c(0.5, 0.6, 0.7, 0.8)
   ) |>
-    aniframe::as_aniframe()
+    anicore::as_aniframe()
 
   result <- filter_na_across(data, "confidence", threshold = 0.6)
 
@@ -91,7 +91,7 @@ test_that("filter_na_confidence handles threshold of 0", {
     y = 4:6,
     confidence = c(-0.1, 0, 0.5)
   ) |>
-    aniframe::as_aniframe()
+    anicore::as_aniframe()
 
   result <- filter_na_across(data, "confidence", threshold = 0)
 
@@ -107,7 +107,7 @@ test_that("filter_na_confidence handles threshold of 1", {
     y = 4:6,
     confidence = c(0.5, 0.99, 1)
   ) |>
-    aniframe::as_aniframe()
+    anicore::as_aniframe()
 
   result <- filter_na_across(data, "confidence", threshold = 1)
 
@@ -123,7 +123,7 @@ test_that("filter_na_confidence preserves existing NAs in x and y", {
     y = c(5, 6, NA, 8),
     confidence = c(0.5, 0.7, 0.8, 0.4)
   ) |>
-    aniframe::as_aniframe()
+    anicore::as_aniframe()
 
   result <- filter_na_across(data, "confidence", threshold = 0.6)
 
@@ -147,7 +147,7 @@ test_that("filter_na_confidence preserves existing NAs in z", {
     z = c(9, NA, 11, 12),
     confidence = c(0.7, 0.8, 0.5, 0.9)
   ) |>
-    aniframe::as_aniframe(variables_where = c("x", "y", "z"))
+    anicore::as_aniframe(variables_where = c("x", "y", "z"))
 
   result <- filter_na_across(data, "confidence", threshold = 0.6)
 
@@ -166,7 +166,7 @@ test_that("filter_na_confidence leaves rows with a missing confidence alone", {
     y = 5:8,
     confidence = c(0.5, NA, 0.8, 0.9)
   ) |>
-    aniframe::as_aniframe()
+    anicore::as_aniframe()
 
   result <- suppressWarnings(filter_na_across(
     data,
@@ -195,7 +195,7 @@ test_that("filter_na_confidence warns about missing confidence values", {
     y = 5:8,
     confidence = c(0.5, NA, NA, 0.9)
   ) |>
-    aniframe::as_aniframe()
+    anicore::as_aniframe()
 
   expect_warning(
     filter_na_across(data, "confidence", threshold = 0.6),
@@ -210,7 +210,7 @@ test_that("filter_na_confidence handles all NAs in confidence", {
     y = 4:6,
     confidence = c(NA_real_, NA_real_, NA_real_)
   ) |>
-    aniframe::as_aniframe()
+    anicore::as_aniframe()
 
   result <- suppressWarnings(filter_na_across(
     data,
@@ -233,7 +233,7 @@ test_that("filter_na_confidence preserves other columns", {
     id = c("a", "b", "c"),
     value = c(10, 20, 30)
   ) |>
-    aniframe::as_aniframe()
+    anicore::as_aniframe()
 
   result <- filter_na_across(data, "confidence", threshold = 0.6)
 
@@ -249,7 +249,7 @@ test_that("filter_na_confidence works with 2D data", {
     y = 4:6,
     confidence = c(0.5, 0.7, 0.9)
   ) |>
-    aniframe::as_aniframe()
+    anicore::as_aniframe()
 
   result <- filter_na_across(data, "confidence", threshold = 0.6)
 
@@ -266,7 +266,7 @@ test_that("filter_na_confidence works with 3D data", {
     z = 7:9,
     confidence = c(0.5, 0.7, 0.9)
   ) |>
-    aniframe::as_aniframe(variables_where = c("x", "y", "z"))
+    anicore::as_aniframe(variables_where = c("x", "y", "z"))
 
   result <- filter_na_across(data, "confidence", threshold = 0.6)
 
@@ -283,7 +283,7 @@ test_that("filter_na_confidence works with polar coordinates", {
     phi = c(0.5, 1.0, 1.5),
     confidence = c(0.5, 0.7, 0.9)
   ) |>
-    aniframe::as_aniframe(variables_where = c("rho", "phi"))
+    anicore::as_aniframe(variables_where = c("rho", "phi"))
 
   result <- filter_na_across(data, "confidence", threshold = 0.6)
 
@@ -320,7 +320,7 @@ test_that("filter_na_confidence validates required columns exist", {
     y = 4:6,
     confidence = c(0.5, 0.7, 0.9)
   ) |>
-    aniframe::as_aniframe()
+    anicore::as_aniframe()
 
   # Dropping a declared column leaves `variables_where` promising it
   data <- dplyr::select(data, -x)
@@ -337,7 +337,7 @@ test_that("filter_na_confidence validates confidence column exists", {
     x = 1:3,
     y = 4:6
   ) |>
-    aniframe::as_aniframe()
+    anicore::as_aniframe()
 
   expect_error(
     filter_na_across(data, "confidence"),
@@ -352,7 +352,7 @@ test_that("filter_na_confidence validates threshold is single numeric", {
     y = 4:6,
     confidence = c(0.5, 0.7, 0.9)
   ) |>
-    aniframe::as_aniframe()
+    anicore::as_aniframe()
 
   # Non-numeric
   expect_error(
@@ -380,7 +380,7 @@ test_that("filter_na_confidence validates threshold is between 0 and 1", {
     y = 4:6,
     confidence = c(0.5, 0.7, 0.9)
   ) |>
-    aniframe::as_aniframe()
+    anicore::as_aniframe()
 
   # Below 0
   expect_error(
@@ -403,7 +403,7 @@ test_that("filter_na_confidence returns an aniframe", {
     z = 7:9,
     confidence = c(0.5, 0.7, 0.9)
   ) |>
-    aniframe::as_aniframe(variables_where = c("x", "y", "z"))
+    anicore::as_aniframe(variables_where = c("x", "y", "z"))
 
   result <- filter_na_across(data, "confidence", threshold = 0.6)
 
@@ -419,7 +419,7 @@ test_that("filter_na_confidence validates confidence column is numeric", {
     y = 4:6,
     confidence = c("low", "medium", "high")
   ) |>
-    aniframe::as_aniframe()
+    anicore::as_aniframe()
 
   expect_error(
     filter_na_across(data, "confidence"),
@@ -453,7 +453,7 @@ test_that("filter_na_confidence coordinate-frame form masks the coordinates", {
 
 test_that("filter_na_confidence coordinate-frame form matches the aniframe form", {
   conf <- c(0.9, 0.2, NA, 0.7)
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:4,
     x = c(1, 2, 3, 4),
     y = c(5, 6, 7, 8),

--- a/tests/testthat/test-filter_na_excursion.R
+++ b/tests/testthat/test-filter_na_excursion.R
@@ -18,7 +18,7 @@ test_that("filter_na_excursion flags a multi-frame excursion that returns", {
   x[100:102] <- 50
   y[100:102] <- 50
 
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = seq_len(n),
     x = x,
     y = y,
@@ -41,7 +41,7 @@ test_that("filter_na_excursion leaves persistent shifts untouched", {
   x <- c(rnorm(n / 2, 0, 1), rnorm(n / 2, 100, 1))
   y <- c(rnorm(n / 2, 0, 1), rnorm(n / 2, 100, 1))
 
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = seq_len(n),
     x = x,
     y = y,
@@ -61,7 +61,7 @@ test_that("filter_na_excursion (per-axis) flags a row when only one axis jumps",
   # Only x jumps; y stays normal.
   x[100:102] <- 50
 
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = seq_len(n),
     x = x,
     y = y,
@@ -84,7 +84,7 @@ test_that("filter_na_excursion (joint Euclidean) flags only when magnitude is la
   x[100:102] <- 50
   y[100:102] <- 50
 
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = seq_len(n),
     x = x,
     y = y,
@@ -105,7 +105,7 @@ test_that("filter_na_excursion blanks confidence at flagged rows", {
   y[100:102] <- 50
   conf <- rep(0.9, n)
 
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = seq_len(n),
     x = x,
     y = y,
@@ -130,7 +130,7 @@ test_that("filter_na_excursion runs per group", {
   y_a[100:102] <- 50
   y_b <- rnorm(n, 0, 1)
 
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     track = rep(c("a", "b"), each = n),
     time = rep(seq_len(n), 2),
     x = c(x_a, x_b),
@@ -147,7 +147,7 @@ test_that("filter_na_excursion runs per group", {
 })
 
 test_that("filter_na_excursion returns an aniframe of the same shape", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:50,
     x = rnorm(50),
     y = rnorm(50),
@@ -162,7 +162,7 @@ test_that("filter_na_excursion returns an aniframe of the same shape", {
 test_that("filter_na_excursion handles trajectories with no σ (constant data)", {
   # σ = 0 means we cannot define the threshold; the algorithm should
   # bail out gracefully and leave data untouched.
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:20,
     x = rep(5, 20),
     y = rep(5, 20),
@@ -184,7 +184,7 @@ test_that("filter_na_excursion coordinate-frame form matches the aniframe form",
   x[10:12] <- x[10:12] + 40
   y <- rnorm(np, sd = 2)
 
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = seq_len(np),
     x = x,
     y = y,
@@ -198,7 +198,7 @@ test_that("filter_na_excursion coordinate-frame form matches the aniframe form",
 })
 
 test_that("filter_na_excursion errors when a variables_where column is missing", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:10,
     x = rnorm(10),
     y = rnorm(10),
@@ -209,7 +209,7 @@ test_that("filter_na_excursion errors when a variables_where column is missing",
 })
 
 test_that("filter_na_excursion errors on non-numeric spatial columns", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:10,
     x = rnorm(10),
     y = rnorm(10),
@@ -220,7 +220,7 @@ test_that("filter_na_excursion errors on non-numeric spatial columns", {
 })
 
 test_that("filter_na_excursion validates threshold arguments", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:50,
     x = rnorm(50),
     y = rnorm(50),
@@ -233,7 +233,7 @@ test_that("filter_na_excursion validates threshold arguments", {
 })
 
 test_that("filter_na_excursion handles short trajectories", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:1,
     x = 1,
     y = 1,
@@ -243,7 +243,7 @@ test_that("filter_na_excursion handles short trajectories", {
 })
 
 test_that("filter_na_excursion (joint) bails out on constant data", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:20,
     x = rep(5, 20),
     y = rep(5, 20),
@@ -261,7 +261,7 @@ test_that("filter_na_excursion preserves existing NAs", {
   y <- rnorm(n, 0, 1)
   x[c(10, 50)] <- NA
   y[c(20, 60)] <- NA
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = seq_len(n),
     x = x,
     y = y,
@@ -290,7 +290,7 @@ test_that("filter_na_excursion treats each group independently", {
   a <- mk_one(0)
   b <- mk_one(5000) # far away, so a merged view would look wild
 
-  grouped <- aniframe::aniframe(
+  grouped <- anicore::aniframe(
     time = c(a$time, b$time),
     individual = rep(c("a", "b"), each = np),
     x = c(a$x, b$x),
@@ -300,7 +300,7 @@ test_that("filter_na_excursion treats each group independently", {
     dplyr::group_by(individual)
 
   alone <- function(d) {
-    res <- filter_na_excursion(aniframe::aniframe(
+    res <- filter_na_excursion(anicore::aniframe(
       time = d$time,
       x = d$x,
       y = d$y,
@@ -317,7 +317,7 @@ test_that("filter_na_excursion treats each group independently", {
 })
 
 test_that("filter_na_excursion leaves one-row groups untouched", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = c(1, 2, 3, 1),
     individual = c("a", "a", "a", "solo"),
     x = c(0, 1, 2, 42),

--- a/tests/testthat/test-filter_na_roi.R
+++ b/tests/testthat/test-filter_na_roi.R
@@ -12,7 +12,7 @@
 # - Error messages are clear
 
 test_that("filter_na_roi filters rectangular ROI with x_min", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:4,
     x = c(0, 5, 10, 15),
     y = c(0, 5, 10, 15)
@@ -25,7 +25,7 @@ test_that("filter_na_roi filters rectangular ROI with x_min", {
 })
 
 test_that("filter_na_roi filters rectangular ROI with x_max", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:4,
     x = c(0, 5, 10, 15),
     y = c(0, 5, 10, 15)
@@ -38,7 +38,7 @@ test_that("filter_na_roi filters rectangular ROI with x_max", {
 })
 
 test_that("filter_na_roi filters rectangular ROI with y_min", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:4,
     x = c(0, 5, 10, 15),
     y = c(0, 5, 10, 15)
@@ -51,7 +51,7 @@ test_that("filter_na_roi filters rectangular ROI with y_min", {
 })
 
 test_that("filter_na_roi filters rectangular ROI with y_max", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:4,
     x = c(0, 5, 10, 15),
     y = c(0, 5, 10, 15)
@@ -64,7 +64,7 @@ test_that("filter_na_roi filters rectangular ROI with y_max", {
 })
 
 test_that("filter_na_roi filters rectangular ROI with multiple boundaries", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:5,
     x = c(0, 5, 10, 15, 20),
     y = c(0, 5, 10, 15, 20)
@@ -84,7 +84,7 @@ test_that("filter_na_roi filters rectangular ROI with multiple boundaries", {
 })
 
 test_that("filter_na_roi handles points on rectangular boundary correctly", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:3,
     x = c(5, 10, 15),
     y = c(5, 10, 15)
@@ -105,7 +105,7 @@ test_that("filter_na_roi handles points on rectangular boundary correctly", {
 })
 
 test_that("filter_na_roi filters cuboid ROI with z_min", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:4,
     x = c(10, 10, 10, 10),
     y = c(10, 10, 10, 10),
@@ -121,7 +121,7 @@ test_that("filter_na_roi filters cuboid ROI with z_min", {
 })
 
 test_that("filter_na_roi filters cuboid ROI with z_max", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:4,
     x = c(10, 10, 10, 10),
     y = c(10, 10, 10, 10),
@@ -137,7 +137,7 @@ test_that("filter_na_roi filters cuboid ROI with z_max", {
 })
 
 test_that("filter_na_roi filters cuboid ROI with all boundaries", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:8,
     x = rep(c(0, 10), 4),
     y = rep(c(0, 10), each = 2, times = 2),
@@ -164,7 +164,7 @@ test_that("filter_na_roi filters cuboid ROI with all boundaries", {
 })
 
 test_that("filter_na_roi filters circular ROI correctly", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:4,
     x = c(0, 3, 6, 9),
     y = c(0, 0, 0, 0)
@@ -185,7 +185,7 @@ test_that("filter_na_roi filters circular ROI correctly", {
 })
 
 test_that("filter_na_roi handles circular ROI with various distances", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:3,
     x = c(5, 8, 10),
     y = c(5, 5, 5)
@@ -208,7 +208,7 @@ test_that("filter_na_roi handles circular ROI with various distances", {
 })
 
 test_that("filter_na_roi filters spherical ROI correctly", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:5,
     x = c(5, 5, 5, 5, 10),
     y = c(5, 5, 5, 8, 5),
@@ -237,7 +237,7 @@ test_that("filter_na_roi filters spherical ROI correctly", {
 })
 
 test_that("filter_na_roi handles spherical ROI boundary", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:3,
     x = c(5, 7, 9),
     y = c(5, 5, 5),
@@ -262,7 +262,7 @@ test_that("filter_na_roi handles spherical ROI boundary", {
 })
 
 test_that("filter_na_roi preserves existing NAs in rectangular ROI", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:4,
     x = c(0, NA, 10, 15),
     y = c(0, 5, NA, 15)
@@ -276,7 +276,7 @@ test_that("filter_na_roi preserves existing NAs in rectangular ROI", {
 })
 
 test_that("filter_na_roi preserves existing NAs in circular ROI", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:3,
     x = c(5, NA, 6),
     y = c(5, 5, NA)
@@ -295,7 +295,7 @@ test_that("filter_na_roi preserves existing NAs in circular ROI", {
 })
 
 test_that("filter_na_roi preserves existing NAs in 3D ROI", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:4,
     x = c(10, NA, 10, 10),
     y = c(10, 10, NA, 10),
@@ -311,7 +311,7 @@ test_that("filter_na_roi preserves existing NAs in 3D ROI", {
 })
 
 test_that("filter_na_roi errors when no parameters provided", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:3,
     x = c(1, 2, 3),
     y = c(1, 2, 3)
@@ -324,7 +324,7 @@ test_that("filter_na_roi errors when no parameters provided", {
 })
 
 test_that("filter_na_roi errors when circular ROI parameters incomplete", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:3,
     x = c(1, 2, 3),
     y = c(1, 2, 3)
@@ -350,7 +350,7 @@ test_that("filter_na_roi errors when circular ROI parameters incomplete", {
 })
 
 test_that("filter_na_roi errors when spherical ROI missing z_center for 3D data", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:3,
     x = c(1, 2, 3),
     y = c(1, 2, 3),
@@ -365,7 +365,7 @@ test_that("filter_na_roi errors when spherical ROI missing z_center for 3D data"
 })
 
 test_that("filter_na_roi errors when z parameters used with 2D data", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:3,
     x = c(1, 2, 3),
     y = c(1, 2, 3)
@@ -390,7 +390,7 @@ test_that("filter_na_roi errors when z parameters used with 2D data", {
 })
 
 test_that("filter_na_roi errors when mixing rectangular and circular params", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:3,
     x = c(1, 2, 3),
     y = c(1, 2, 3)
@@ -415,7 +415,7 @@ test_that("filter_na_roi rejects input that is neither aniframe nor data frame",
 
 test_that("filter_na_roi coordinate-frame form matches the aniframe form", {
   coords <- data.frame(x = c(0, 10, 20), y = c(0, 10, 20))
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:3,
     x = coords$x,
     y = coords$y,
@@ -439,7 +439,7 @@ test_that("filter_na_roi needs x and y coordinates", {
 })
 
 test_that("filter_na_roi_rect handles each boundary independently", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:3,
     x = c(0, 10, 20),
     y = c(0, 10, 20)
@@ -499,7 +499,7 @@ test_that("filter_na_roi_rect handles each boundary independently", {
 })
 
 test_that("filter_na_roi_rect handles z boundaries in 3D", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:3,
     x = c(10, 10, 10),
     y = c(10, 10, 10),
@@ -537,7 +537,7 @@ test_that("filter_na_roi_rect handles z boundaries in 3D", {
 })
 
 test_that("filter_na_roi_sphere calculates 2D distance correctly", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:5,
     x = c(2, 3, 5, 7, 8),
     y = c(4, 4, 4, 4, 4)
@@ -558,7 +558,7 @@ test_that("filter_na_roi_sphere calculates 2D distance correctly", {
 })
 
 test_that("filter_na_roi_sphere calculates 3D distance correctly", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:4,
     x = c(5, 5, 5, 8),
     y = c(5, 5, 8, 5),
@@ -584,7 +584,7 @@ test_that("filter_na_roi_sphere calculates 3D distance correctly", {
 })
 
 test_that("filter_na_roi returns an aniframe", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:3,
     x = c(1, 5, 10),
     y = c(1, 5, 10)
@@ -596,7 +596,7 @@ test_that("filter_na_roi returns an aniframe", {
 })
 
 test_that("filter_na_roi works with grid data", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:9,
     x = rep(c(0, 5, 10), 3),
     y = rep(c(0, 5, 10), each = 3)
@@ -619,7 +619,7 @@ test_that("filter_na_roi works with grid data", {
 })
 
 test_that("filter_na_roi errors when no ROI parameters are given (3D)", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:5,
     x = 1:5,
     y = 1:5,

--- a/tests/testthat/test-filter_na_speed.R
+++ b/tests/testthat/test-filter_na_speed.R
@@ -15,7 +15,7 @@
 
 test_that("filter_na_speed flags a single-frame outlier (2D)", {
   # Smooth motion with one position outlier at index 5
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:9,
     x = c(1, 2, 3, 4, 100, 6, 7, 8, 9),
     y = c(1, 2, 3, 4, 100, 6, 7, 8, 9)
@@ -34,7 +34,7 @@ test_that("filter_na_speed flags a single-frame outlier (2D)", {
 })
 
 test_that("filter_na_speed flags a single-frame outlier (3D)", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:9,
     x = c(1, 2, 3, 4, 100, 6, 7, 8, 9),
     y = c(1, 2, 3, 4, 100, 6, 7, 8, 9),
@@ -53,7 +53,7 @@ test_that("filter_na_speed flags a single-frame outlier (3D)", {
 
 test_that("filter_na_speed leaves legitimate step changes alone", {
   # Sustained move to a new region (not an outlier)
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:8,
     x = c(1, 2, 3, 100, 101, 102, 103, 104),
     y = c(1, 2, 3, 100, 101, 102, 103, 104)
@@ -68,7 +68,7 @@ test_that("filter_na_speed leaves legitimate step changes alone", {
 
 test_that("filter_na_speed calculates auto threshold", {
   # Data with one single-frame outlier at index 51
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:100,
     x = c(1:50, 500, 51:99),
     y = 1:100
@@ -83,7 +83,7 @@ test_that("filter_na_speed calculates auto threshold", {
 })
 
 test_that("filter_na_speed preserves existing NAs", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:5,
     x = c(0, NA, 2, 3, 4),
     y = c(0, 1, NA, 3, 4)
@@ -98,7 +98,7 @@ test_that("filter_na_speed preserves existing NAs", {
 
 test_that("filter_na_speed does not contaminate neighbors of NA inputs", {
   # Single NA in x at row 3 of an otherwise clean series
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:7,
     x = c(1, 2, NA, 4, 5, 6, 7),
     y = c(1, 2, 3, 4, 5, 6, 7)
@@ -114,7 +114,7 @@ test_that("filter_na_speed does not contaminate neighbors of NA inputs", {
 })
 
 test_that("filter_na_speed preserves other columns", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:5,
     x = c(0, 1, 2, 3, 4),
     y = c(0, 1, 2, 3, 4),
@@ -129,7 +129,7 @@ test_that("filter_na_speed preserves other columns", {
 })
 
 test_that("filter_na_speed filters confidence when present", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:7,
     x = c(1, 2, 3, 100, 5, 6, 7),
     y = c(1, 2, 3, 100, 5, 6, 7),
@@ -143,7 +143,7 @@ test_that("filter_na_speed filters confidence when present", {
 })
 
 test_that("filter_na_speed works without confidence column", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:5,
     x = c(0, 1, 2, 3, 4),
     y = c(0, 1, 2, 3, 4)
@@ -169,7 +169,7 @@ test_that("filter_na_speed validates data is an aniframe", {
 })
 
 test_that("filter_na_speed validates required columns exist", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:5,
     x = c(0, 1, 2, 3, 4),
     y = c(0, 1, 2, 3, 4)
@@ -184,7 +184,7 @@ test_that("filter_na_speed validates required columns exist", {
 })
 
 test_that("filter_na_speed validates columns are numeric", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:5,
     x = c(0, 1, 2, 3, 4),
     y = c(0, 1, 2, 3, 4)
@@ -198,7 +198,7 @@ test_that("filter_na_speed validates columns are numeric", {
 })
 
 test_that("filter_na_speed validates threshold is auto or numeric", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:5,
     x = c(0, 1, 2, 3, 4),
     y = c(0, 1, 2, 3, 4)
@@ -216,7 +216,7 @@ test_that("filter_na_speed validates threshold is auto or numeric", {
 })
 
 test_that("filter_na_speed returns an aniframe", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:5,
     x = c(0, 1, 2, 3, 4),
     y = c(0, 1, 2, 3, 4)
@@ -228,7 +228,7 @@ test_that("filter_na_speed returns an aniframe", {
 })
 
 test_that("filter_na_speed handles constant position", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:5,
     x = c(5, 5, 5, 5, 5),
     y = c(5, 5, 5, 5, 5)
@@ -243,7 +243,7 @@ test_that("filter_na_speed handles constant position", {
 
 test_that("filter_na_speed handles uneven time spacing", {
   # Single-frame outlier on an uneven time grid
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = c(0, 1, 2, 2.1, 2.2, 3, 4),
     x = c(0, 1, 2, 100, 4, 5, 6),
     y = c(0, 1, 2, 100, 4, 5, 6)
@@ -310,7 +310,7 @@ test_that("calculate_step_speed returns NA for groups too short to step", {
 })
 
 test_that("filter_na_speed errors when time column is missing", {
-  data <- aniframe::aniframe(
+  data <- anicore::aniframe(
     time = 1:5,
     x = 1:5,
     y = 1:5,
@@ -325,7 +325,7 @@ test_that("filter_na_speed errors when time column is missing", {
 # Two individuals stacked in one aniframe, `sep` units apart, time restarting
 # per individual. Individual "a" has one genuine single-frame outlier.
 speed_fixture <- function(sep, np = 30) {
-  aniframe::aniframe(
+  anicore::aniframe(
     time = rep(seq_len(np), 2),
     individual = rep(c("a", "b"), each = np),
     x = c(c(0:3, 500, 5:(np - 1)), (0:(np - 1)) + sep),
@@ -365,7 +365,7 @@ test_that("filter_na_speed auto threshold ignores cross-track steps", {
   # Two stationary individuals: every within-track speed is 0, so the
   # threshold must be 0 no matter how far apart they are.
   fixture <- function(sep) {
-    aniframe::aniframe(
+    anicore::aniframe(
       time = rep(1:10, 2),
       individual = rep(c("a", "b"), each = 10),
       x = c(rep(0, 10), rep(sep, 10)),
@@ -388,7 +388,7 @@ test_that("filter_na_speed auto threshold ignores cross-track steps", {
 test_that("filter_na_speed leaves one-row groups untouched", {
   # A group with fewer than two rows has no step, so speed is NA. if_else()
   # propagates a missing condition, which would blank an otherwise fine row.
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = c(1, 2, 3, 1),
     individual = c("a", "a", "a", "solo"),
     x = c(0, 1, 2, 42),
@@ -405,7 +405,7 @@ test_that("filter_na_speed leaves one-row groups untouched", {
 })
 
 test_that("filter_na_speed is unchanged on ungrouped data", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:10,
     x = c(0:3, 500, 5:9),
     y = rep(0, 10),
@@ -439,7 +439,7 @@ test_that("filter_na_speed coordinate-frame form matches the aniframe form", {
   x <- c(0:3, 500, 5:9)
   y <- rep(0, 10)
   tm <- 1:10
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = tm,
     x = x,
     y = y,
@@ -455,7 +455,7 @@ test_that("filter_na_speed coordinate-frame form matches the aniframe form", {
 test_that("filter_na_speed works inside mutate via pick()", {
   set.seed(9)
   np <- 20
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = rep(seq_len(np), 2),
     individual = rep(c("a", "b"), each = np),
     x = c(c(0:8, 500, 10:19), (0:19) + 1000),

--- a/tests/testthat/test-filter_na_with.R
+++ b/tests/testthat/test-filter_na_with.R
@@ -83,7 +83,7 @@ test_that("filter_na_with preserves shape", {
 })
 
 test_that("filter_na_with rejects an aniframe", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:9,
     x = as.numeric(1:9),
     y = as.numeric(1:9),

--- a/tests/testthat/test-filter_one_euro.R
+++ b/tests/testthat/test-filter_one_euro.R
@@ -226,13 +226,13 @@ test_that("filter_one_euro is reachable through the generics", {
     filter_one_euro(x, sampling_rate = 60, beta = 0.5)
   )
 
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = seq_len(60),
     x = x,
     y = rev(x),
     variables_what = character(0)
   )
-  d <- aniframe::set_metadata(d, sampling_rate = 60)
+  d <- anicore::set_metadata(d, sampling_rate = 60)
 
   # sampling_rate comes from the aniframe's metadata
   expect_equal(

--- a/tests/testthat/test-filter_with.R
+++ b/tests/testthat/test-filter_with.R
@@ -106,7 +106,7 @@ test_that("filter_with dispatches ccma on a frame", {
 })
 
 test_that("filter_with rejects an aniframe", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:9,
     x = as.numeric(1:9),
     y = as.numeric(1:9),

--- a/tests/testthat/test-replace_na_across.R
+++ b/tests/testthat/test-replace_na_across.R
@@ -6,7 +6,7 @@
 
 gap_fixture <- function() {
   np <- 10
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = rep(seq_len(np), 2),
     individual = rep(c("a", "b"), each = np),
     x = c(c(1, NA, 3, 4, 5, 6, 7, 8, 9, 10), c(101:110)),
@@ -54,7 +54,7 @@ test_that("replace_na_across fills within groups only", {
   # Track a ends with a gap; track b starts far away. A cross-boundary
   # fill would interpolate between the two.
   np <- 5
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = rep(seq_len(np), 2),
     individual = rep(c("a", "b"), each = np),
     x = c(c(1, 2, 3, 4, NA), c(1000, 1001, 1002, 1003, 1004)),

--- a/tests/testthat/test-replace_na_with.R
+++ b/tests/testthat/test-replace_na_with.R
@@ -82,7 +82,7 @@ test_that("replace_na_with rejects an unknown method", {
 })
 
 test_that("replace_na_with rejects an aniframe", {
-  d <- aniframe::aniframe(
+  d <- anicore::aniframe(
     time = 1:3,
     x = c(1, NA, 3),
     y = c(1, 2, 3),


### PR DESCRIPTION
## Description

### What kind of change is this?

- [ ] Bug fix
- [ ] Addition of a new feature
- [ ] Documentation
- [x] Maintenance (CI, dependencies, refactoring)
- [ ] Other

> **Draft, and must stay one until `anicore` is published to r-universe.** CI cannot resolve the dependency before then, so this will fail until the core package releases. Part of a coordinated sweep across the organisation for animovement/aniframe#127.

### Why is it needed?

The core package is renamed from `aniframe` to `anicore` (animovement/aniframe#127). It is no longer one class's home — it declares `aniframe`, `anievent` and the types the domain packages build on, while producing almost none of them.

### What does it do?

**Only the package reference changes.** The `aniframe` *class* keeps its name, so every one of these is deliberately untouched:

```r
as_aniframe()   is_aniframe()   validate_aniframe()   aniframe_kin
read_aniframe() write_aniframe() summarise_aniframe()
inherits(x, "aniframe")     expect_s3_class(result, "aniframe")
"An aniframe object"        <aniframe>
```

What moves is the package: `library()`, `::`, the `DESCRIPTION` dependency, roxygen `@import` / `@importFrom`, `\link[]` targets, URLs and badges.

### How the split was made

A rule-based rewrite, with every rule an unambiguous package context — namespace-qualified calls, `library()`/`require()`, `requireNamespace()`/`packageVersion()`, `install.packages()`, GitHub/pkgdown/r-universe/codecov URLs, DESCRIPTION dependency entries, and prose of the form "the aniframe package". Anything else mentioning the word was **reported rather than rewritten**, and reviewed by hand.

That mattered: a census across the organisation found quoted `"aniframe"` is almost entirely *class* context — 48 of ~60 are `expect_s3_class(result, "aniframe")` — so a blanket find-and-replace would have broken the test suites while looking like it worked.

Two categories were decided by hand rather than by rule:

- **Markdown links whose text names the package** (`[aniframe](https://animovement.dev/…)`) were changed only where the sentence means the package. Where it means the object — *"inspecting the resulting [aniframe]"* — the text stays and only the URL moves.
- **Historical `NEWS.md` entries** such as ``* `aniframe (>= 0.6.0)` is now required`` are left alone. Those describe releases where the dependency genuinely was `aniframe`; rewriting them would falsify the changelog.

## References

animovement/aniframe#127.

## How has this PR been tested?

`anicore` was installed into this project's library and the documentation regenerated against it, so `man/` and `NAMESPACE` reflect the new package name. Full `R CMD check` is not meaningful until `anicore` is on r-universe — that is what the draft status is for.

## Is this a breaking change?

No — this repository's own API is unchanged. It adopts a renamed dependency.

## Checklist

- [x] Documentation regenerated if roxygen comments changed (`devtools::document()`)
- [ ] Tests pass locally — blocked on `anicore` being published
- [x] I have read and understood every change I am submitting

🤖 Generated with [Claude Code](https://claude.com/claude-code)
